### PR TITLE
ci: re-add docs workflow

### DIFF
--- a/.github/workflows/create-pr.sh
+++ b/.github/workflows/create-pr.sh
@@ -1,0 +1,36 @@
+# Adapted from https://github.com/paygoc6/action-pull-request-another-repo
+
+CLONE_DIR=$(mktemp -d)
+
+echo "Setting git variables"
+export GITHUB_TOKEN=$API_TOKEN_GITHUB
+git config --global user.email "$USER_EMAIL"
+git config --global user.name "$USER_NAME"
+
+echo "Cloning destination git repository"
+git clone "https://$API_TOKEN_GITHUB@github.com/$DESTINATION_REPO.git" "$CLONE_DIR"
+cd "$CLONE_DIR"
+git checkout "$DESTINATION_BASE_BRANCH"
+git pull origin "$DESTINATION_BASE_BRANCH"
+git checkout -b "$DESTINATION_HEAD_BRANCH"
+
+echo "Copying contents to git repo"
+mkdir -p "$CLONE_DIR/$DESTINATION_FOLDER"
+cp -r "$SOURCE_FOLDER/." "$CLONE_DIR/$DESTINATION_FOLDER/"
+
+echo "Adding files"
+git add .
+if git status | grep -q "Changes to be committed"
+then
+  echo "Adding git commit"
+  git commit -m "$COMMIT_MESSAGE"
+  echo "Pushing git commit"
+  git push -u origin "$DESTINATION_HEAD_BRANCH"
+  echo "Creating a pull request"
+  gh pr create -t "$PR_TITLE" \
+               -B "$DESTINATION_BASE_BRANCH" \
+               -b "" \
+               -H "$DESTINATION_HEAD_BRANCH"
+else
+  echo "No changes detected"
+fi

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -1,0 +1,38 @@
+name: documentation
+on:
+  push:
+    branches:
+      - 'main'
+      - 'master'
+jobs:
+  Push-Docs-To-AzerothCore-Website:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v2
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.x'
+          architecture: 'x64'
+      - name: Install Python dependencies
+        run: pip install jinja2 typedecorator markdown
+      - name: Compile documentation
+        run: |
+          cd ${{ github.workspace }}/src/LuaEngine/docs/
+          python -m ElunaDoc
+      - name: Create pull request
+        run: |
+          chmod +x "${GITHUB_WORKSPACE}/.github/workflows/create-pr.sh"
+          "${GITHUB_WORKSPACE}/.github/workflows/create-pr.sh"
+        env:
+          API_TOKEN_GITHUB: ${{ secrets.API_TOKEN_GITHUB }}
+          SOURCE_FOLDER: '${{ github.workspace }}/src/LuaEngine/docs/build'
+          DESTINATION_REPO: 'azerothcore/azerothcore.github.io'
+          DESTINATION_FOLDER: 'pages/eluna'
+          DESTINATION_BASE_BRANCH: 'master'
+          DESTINATION_HEAD_BRANCH: 'eluna-docs'
+          PR_TITLE: 'chore: update eluna documentation'
+          COMMIT_MESSAGE: 'chore: update eluna documentation'
+          USER_EMAIL: 'ax.cocat@gmail.com'
+          USER_NAME: 'r-o-b-o-t-o'


### PR DESCRIPTION
Re-adds the workflow from https://github.com/azerothcore/mod-eluna/pull/22

This adds a Github action to automatically push the changes made to the documentation to [azerothcore/azerothcore.github.io](https://github.com/azerothcore/azerothcore.github.io/tree/master/pages/eluna) in the form of a pull request