### PR TITLE
feat(Core/Player): SendListInventory with vendor id

### DIFF
--- a/src/LuaEngine/PlayerMethods.h
+++ b/src/LuaEngine/PlayerMethods.h
@@ -2362,8 +2362,9 @@ namespace LuaPlayer
     int SendListInventory(lua_State* L, Player* player)
     {
         WorldObject* obj = Eluna::CHECKOBJ<WorldObject>(L, 2);
+        uint32 vendorId = Eluna::CHECKVAL<uint32>(L, 3, 0);
 
-        player->GetSession()->SendListInventory(obj->GET_GUID());
+        player->GetSession()->SendListInventory(obj->GET_GUID(), vendorId);
         return 0;
     }
 


### PR DESCRIPTION
Updated SendListInventory to allow specifying which vendor entry to send to the player.

Tested with a creature template entry of 9000000 with 129 set as npcflag and with a npc_vendor entry. The first option opens the vendor offered by the stormwind innkeeper while the second one defaults to the creature you're talking to.
```lua
local function VendorOnGossipHello(event, player, object)
    player:GossipClearMenu()
    player:GossipMenuAddItem(7, "I want something", 1, 100)
    player:GossipMenuAddItem(7, "I want something else", 1, 200)
    player:GossipSendMenu(0x7FFFFFFF, object, 1)
end

local function VendorOnGossipSelect(event, player, object, sender, intid, code, menu_id)
    if (intid == 100) then
        player:SendListInventory(object, 6740) -- entry 6740 from npc_vendor
    elseif (intid == 200) then
        player:SendListInventory(object) -- defaults to creature entry from npc_vendor
    end
end

RegisterCreatureGossipEvent(9000000, 1, VendorOnGossipHello)
RegisterCreatureGossipEvent(9000000, 2, VendorOnGossipSelect)
```

All credit goes to **Foe** on Discord, whichever username that may be on Github.