### PR TITLE
feat: GameObject:AddLoot()

### DIFF
--- a/src/LuaEngine/LuaFunctions.cpp
+++ b/src/LuaEngine/LuaFunctions.cpp
@@ -916,6 +916,7 @@ ElunaRegister<GameObject> GameObjectMethods[] =
     { "Despawn", &LuaGameObject::Despawn },
     { "Respawn", &LuaGameObject::Respawn },
     { "SaveToDB", &LuaGameObject::SaveToDB },
+    { "AddLoot", &LuaGameObject::AddLoot },
 
     { NULL, NULL }
 };


### PR DESCRIPTION
Adds a new method to gameobjects, which allows spawning loot at runtime in an **empty** container.
Co-authored by @r-o-b-o-t-o 

Tested with:
```SQL
##Copy of the Arena Chest with 0 loot
INSERT INTO `gameobject_template` (`entry`, `type`, `displayId`, `name`, `IconName`, `castBarCaption`, `unk1`, `size`, `Data0`, `Data1`, `Data2`, `Data3`, `Data4`, `Data5`, `Data6`, `Data7`, `Data8`, `Data9`, `Data10`, `Data11`, `Data12`, `Data13`, `Data14`, `Data15`, `Data16`, `Data17`, `Data18`, `Data19`, `Data20`, `Data21`, `Data22`, `Data23`, `AIName`, `ScriptName`, `VerifiedBuild`) VALUES ('510001', '3', '259', 'Treasure Chest', '', '', '', '1', '1599', '0', '0', '1', '0', '0', '0', '0', '0', '0', '0', '0', '0', '0', '0', '0', '0', '0', '0', '0', '0', '0', '0', '0', '', '', '0');
```


```lua
local function OnCommand( event, player, command, chatHandler )
    if command == 'test' and player then
        local go = player:SummonGameObject( 510001, player:GetX(), player:GetY(), player:GetZ(), player:GetO(), 30 )
        if go then
            go:AddLoot(13463,8,23054,1)          --12 Dreamfoil and 1 Gressil
        end
    end
end

RegisterPlayerEvent( 42, OnCommand, 0 )
```