### PR TITLE
feat: add player event OnFfaPvpStateUpdate

### DIFF
--- a/src/ElunaLuaEngine_SC.cpp
+++ b/src/ElunaLuaEngine_SC.cpp
@@ -741,6 +741,11 @@ public:
     {
         sEluna->OnAchiComplete(player, achievement);
     }
+
+    void OnFfaPvpStateUpdate(Player* player, bool IsFlaggedForFfaPvp) override
+    {
+        sEluna->OnFfaPvpStateUpdate(player, IsFlaggedForFfaPvp);
+    }
 };
 
 class Eluna_ServerScript : public ServerScript

--- a/src/LuaEngine/GlobalMethods.h
+++ b/src/LuaEngine/GlobalMethods.h
@@ -708,6 +708,7 @@ namespace LuaGlobalFunctions
      *     PLAYER_EVENT_ON_PET_ADDED_TO_WORLD      =     43,       // (event, player, pet)
      *     PLAYER_EVENT_ON_LEARN_SPELL             =     44,       // (event, player, spellId)
      *     PLAYER_EVENT_ON_ACHIEVEMENT_COMPLETE    =     45,       // (event, player, achievement)
+     *     PLAYER_EVENT_ON_FFAPVP_CHANGE           =     46,       // (event, player, hasFfaPvp)
      * };
      * </pre>
      *

--- a/src/LuaEngine/Hooks.h
+++ b/src/LuaEngine/Hooks.h
@@ -145,7 +145,7 @@ namespace Hooks
 
         // AddOns
         ADDON_EVENT_ON_MESSAGE                  =     30,       // (event, sender, type, prefix, msg, target) - target can be nil/whisper_target/guild/group/channel. Can return false
-        
+
         WORLD_EVENT_ON_DELETE_CREATURE          =     31,       // (event, creature)
         WORLD_EVENT_ON_DELETE_GAMEOBJECT        =     32,       // (event, gameobject)
 
@@ -207,6 +207,7 @@ namespace Hooks
         PLAYER_EVENT_ON_PET_ADDED_TO_WORLD      =     43,       // (event, player, pet)
         PLAYER_EVENT_ON_LEARN_SPELL             =     44,       // (event, player, spellId)
         PLAYER_EVENT_ON_ACHIEVEMENT_COMPLETE    =     45,       // (event, player, achievement)
+        PLAYER_EVENT_ON_FFAPVP_CHANGE           =     46,       // (event, player, hasFfaPvp)
 
         PLAYER_EVENT_COUNT
     };

--- a/src/LuaEngine/LuaEngine.h
+++ b/src/LuaEngine/LuaEngine.h
@@ -474,6 +474,7 @@ public:
     void HandleGossipSelectOption(Player* pPlayer, uint32 menuId, uint32 sender, uint32 action, const std::string& code);
     void OnLearnSpell(Player* player, uint32 spellId);
     void OnAchiComplete(Player* player, AchievementEntry const* achievement);
+    void OnFfaPvpStateUpdate(Player* player, bool hasFfaPvp);
 
 #ifndef CLASSIC
 #ifndef TBC

--- a/src/LuaEngine/PlayerHooks.cpp
+++ b/src/LuaEngine/PlayerHooks.cpp
@@ -574,3 +574,12 @@ void Eluna::OnAchiComplete(Player* player, AchievementEntry const* achievement)
     Push(achievement);
     CallAllFunctions(PlayerEventBindings, key);
 }
+
+
+void Eluna::OnFfaPvpStateUpdate(Player* player, bool hasFfaPvp)
+{
+    START_HOOK(PLAYER_EVENT_ON_FFAPVP_CHANGE);
+    Push(player);
+    Push(hasFfaPvp);
+    CallAllFunctions(PlayerEventBindings, key);
+}


### PR DESCRIPTION
Co-authored by https://github.com/DavuKnight
Tested with
```lua
local function OnFfaPvpChange(event, player, hasFfaPvp)
    print('Firing OnFfaPvpChange')
    if player then
        print( player:GetName() )
        print(hasFfaPvp)
    end
end

RegisterPlayerEvent(46, OnFfaPvpChange)
```