### PR TITLE
Add config option to send reload message to non-0 security level players.

### DIFF
--- a/conf/mod_LuaEngine.conf.dist
+++ b/conf/mod_LuaEngine.conf.dist
@@ -19,10 +19,16 @@
 #                    The path can be relative or absolute.
 #       Default:    "lua_scripts"
 #
+#   Eluna.PlayerAnnounceReload
+#       Description: Enable or disable whether the reload announcement is sent to players (Lowest security level).
+#       Default:    false - (disabled)
+#                   true  - (enabled)
+#
 
 Eluna.Enabled = true
 Eluna.TraceBack = false
 Eluna.ScriptPath = "lua_scripts"
+Eluna.PlayerAnnounceReload = false
 
 
 ###################################################################################################

--- a/src/LuaEngine/LuaEngine.cpp
+++ b/src/LuaEngine/LuaEngine.cpp
@@ -133,7 +133,10 @@ void Eluna::_ReloadEluna()
     LOCK_ELUNA;
     ASSERT(IsInitialized());
 
-    eWorld->SendServerMessage(SERVER_MSG_STRING, "Reloading Eluna...");
+    if (eConfigMgr->GetOption<bool>("Eluna.PlayerAnnounceReload", false))
+        eWorld->SendServerMessage(SERVER_MSG_STRING, "Reloading Eluna...");
+    else
+        eWorld->SendGMText(SERVER_MSG_STRING, "Reloading Eluna...");
 
     // Remove all timed events
     sEluna->eventMgr->SetStates(LUAEVENT_STATE_ERASE);


### PR DESCRIPTION
Closes #61 
By default set to send to >0 security players.