### PR TITLE
feat: add Player:GetMailCount()

### DIFF
--- a/src/LuaEngine/LuaFunctions.cpp
+++ b/src/LuaEngine/LuaFunctions.cpp
@@ -471,6 +471,7 @@ ElunaRegister<Player> PlayerMethods[] =
     { "GetItemByPos", &LuaPlayer::GetItemByPos },
     { "GetItemByEntry", &LuaPlayer::GetItemByEntry },
     { "GetItemByGUID", &LuaPlayer::GetItemByGUID },
+    { "GetMailCount", &LuaPlayer::GetMailCount },
     { "GetMailItem", &LuaPlayer::GetMailItem },
     { "GetReputation", &LuaPlayer::GetReputation },
     { "GetEquippedItemBySlot", &LuaPlayer::GetEquippedItemBySlot },

--- a/src/LuaEngine/PlayerMethods.h
+++ b/src/LuaEngine/PlayerMethods.h
@@ -1384,6 +1384,26 @@ namespace LuaPlayer
     }
 
     /**
+     * Returns the amount of mails in the player's mailbox.
+     *
+     * @return uint32 mailCount
+     */
+    int GetMailCount(lua_State* L, Player* player)
+    {
+        const CharacterCacheEntry* cache = sCharacterCache->GetCharacterCacheByGuid(player->GetGUID());
+        if (cache)
+        {
+            Eluna::Push(L, static_cast<uint32>(cache->MailCount));
+        }
+        else
+        {
+            Eluna::Push(L, player->GetMailSize());
+        }
+
+        return 1;
+    }
+
+    /**
      * Returns a mailed [Item] by guid.
      *
      * @param ObjectGuid guid : an item guid


### PR DESCRIPTION
Adds `Player:GetMailCount()`:
> Returns the amount of mails in the player's mailbox.