### PR TITLE
feat: add Player:GetAchievementCriteriaProgress()

### DIFF
--- a/src/LuaEngine/LuaFunctions.cpp
+++ b/src/LuaEngine/LuaFunctions.cpp
@@ -612,6 +612,7 @@ ElunaRegister<Player> PlayerMethods[] =
     // {"HasPendingBind", &LuaPlayer::HasPendingBind},                                      // :HasPendingBind() - UNDOCUMENTED - Returns true if the player has a pending instance bind
 #if (!defined(TBC) && !defined(CLASSIC))
     { "HasAchieved", &LuaPlayer::HasAchieved },
+    { "GetAchievementCriteriaProgress", &LuaPlayer::GetAchievementCriteriaProgress },
 #if defined(TRINITY) || defined(AZEROTHCORE)
     { "SetAchievement", &LuaPlayer::SetAchievement },
 #endif

--- a/src/LuaEngine/PlayerMethods.h
+++ b/src/LuaEngine/PlayerMethods.h
@@ -64,6 +64,28 @@ namespace LuaPlayer
 #endif
         return 1;
     }
+
+    /**
+     * Returns the progress of the [Player] for the specified achievement criteria.
+     *
+     * @param uint32 criteriaId
+     * @return uint32 progress : progress value or nil
+     */
+    int GetAchievementCriteriaProgress(lua_State* L, Player* player)
+    {
+        uint32 criteriaId = Eluna::CHECKVAL<uint32>(L, 2);
+        const AchievementCriteriaEntry* criteria = sAchievementCriteriaStore.LookupEntry(criteriaId);
+        CriteriaProgress* progress = player->GetAchievementMgr()->GetCriteriaProgress(criteria);
+        if (progress)
+        {
+            Eluna::Push(L, progress->counter);
+        }
+        else
+        {
+            Eluna::Push(L, (void*)nullptr);
+        }
+        return 1;
+    }
 #endif
 
     /**


### PR DESCRIPTION
Adds `Player:GetAchievementCriteriaProgress()`:
> Returns the progress of the player for the specified achievement criteria.

**Requires https://github.com/azerothcore/azerothcore-wotlk/pull/14387**