### PR TITLE
feat: add getter and setter for halaa ownership

### DIFF
--- a/src/LuaEngine/GlobalMethods.h
+++ b/src/LuaEngine/GlobalMethods.h
@@ -13,6 +13,9 @@
 
 #include "BanMgr.h"
 #include "GameTime.h"
+#include "SharedDefines.h"
+#include "OutdoorPvPMgr.h"
+#include "../../../../src/server/scripts/OutdoorPvP/OutdoorPvPNA.h"
 
 enum BanMode
 {
@@ -3322,5 +3325,51 @@ namespace LuaGlobalFunctions
 
         return 0;
     }
+
+    #ifdef AZEROTHCORE
+    /**
+     * Gets the faction which is the current owner of Halaa in Nagrand
+     * 0 = Alliance
+     * 1 = Horde
+     *
+     * @return int16 the ID of the team to own Halaa
+     */
+    int GetOwnerHalaa(lua_State* L)
+    {
+        OutdoorPvPNA* nagrandPvp = (OutdoorPvPNA*)sOutdoorPvPMgr->GetOutdoorPvPToZoneId(3518);
+        OPvPCapturePointNA* halaa = nagrandPvp->GetCapturePoint();
+        Eluna::Push(L, halaa->GetControllingFaction());
+
+        return 1;
+    }
+
+    /**
+     * Sets the owner of Halaa in Nagrand to the respective faction
+     * 0 = Alliance
+     * 1 = Horde
+     *
+     * @param uint16 teamId : the ID of the team to own Halaa
+     */
+    int SetOwnerHalaa(lua_State* L)
+    {
+        uint16 teamId = Eluna::CHECKVAL<uint16>(L, 1);
+
+        OutdoorPvPNA* nagrandPvp = (OutdoorPvPNA*)sOutdoorPvPMgr->GetOutdoorPvPToZoneId(3518);
+        OPvPCapturePointNA* halaa = nagrandPvp->GetCapturePoint();
+
+        if (teamId == 0)
+        {
+            halaa->FactionTakeOver(TEAM_ALLIANCE);
+            halaa->m_value = 1024;
+        }
+        else if (teamId == 1)
+        {
+            halaa->FactionTakeOver(TEAM_HORDE);
+            halaa->m_value = -1024;
+        }
+
+        return 0;
+    }
+    #endif
 }
 #endif

--- a/src/LuaEngine/GlobalMethods.h
+++ b/src/LuaEngine/GlobalMethods.h
@@ -3332,8 +3332,8 @@ namespace LuaGlobalFunctions
      * 0 = Alliance
      * 1 = Horde
      *
-     * 1024 = slider max Alliance
-     * -1024 = slider max Horde
+     * 600 = slider max Alliance
+     * -600 = slider max Horde
      *
      * @return int16 the ID of the team to own Halaa
      * @return float the slider position.

--- a/src/LuaEngine/GlobalMethods.h
+++ b/src/LuaEngine/GlobalMethods.h
@@ -3332,11 +3332,11 @@ namespace LuaGlobalFunctions
      * 0 = Alliance
      * 1 = Horde
      *
-     * 600 = slider max Alliance
-     * -600 = slider max Horde
+     * 1024 = slider max Alliance
+     * -1024 = slider max Horde
      *
      * @return int16 the ID of the team to own Halaa
-     * €@return float the slider position.
+     * @return float the slider position.
      */
     int GetOwnerHalaa(lua_State* L)
     {
@@ -3364,12 +3364,10 @@ namespace LuaGlobalFunctions
 
         if (teamId == 0)
         {
-            halaa->FactionTakeOver(TEAM_ALLIANCE);
             halaa->SetSlider(599);
         }
         else if (teamId == 1)
         {
-            halaa->FactionTakeOver(TEAM_HORDE);
             halaa->SetSlider(-599);
         }
         else

--- a/src/LuaEngine/GlobalMethods.h
+++ b/src/LuaEngine/GlobalMethods.h
@@ -3332,15 +3332,20 @@ namespace LuaGlobalFunctions
      * 0 = Alliance
      * 1 = Horde
      *
+     * 600 = slider max Alliance
+     * -600 = slider max Horde
+     *
      * @return int16 the ID of the team to own Halaa
+     * €@return float the slider position.
      */
     int GetOwnerHalaa(lua_State* L)
     {
         OutdoorPvPNA* nagrandPvp = (OutdoorPvPNA*)sOutdoorPvPMgr->GetOutdoorPvPToZoneId(3518);
         OPvPCapturePointNA* halaa = nagrandPvp->GetCapturePoint();
         Eluna::Push(L, halaa->GetControllingFaction());
+        Eluna::Push(L, halaa->GetSlider());
 
-        return 1;
+        return 2;
     }
 
     /**
@@ -3360,12 +3365,16 @@ namespace LuaGlobalFunctions
         if (teamId == 0)
         {
             halaa->FactionTakeOver(TEAM_ALLIANCE);
-            halaa->m_value = 1024;
+            halaa->SetSlider(599);
         }
         else if (teamId == 1)
         {
             halaa->FactionTakeOver(TEAM_HORDE);
-            halaa->m_value = -1024;
+            halaa->SetSlider(-599);
+        }
+        else
+        {
+            return luaL_argerror(L, 1, "0 for Alliance or 1 for Horde expected");
         }
 
         return 0;

--- a/src/LuaEngine/LuaFunctions.cpp
+++ b/src/LuaEngine/LuaFunctions.cpp
@@ -98,6 +98,7 @@ luaL_Reg GlobalMethods[] =
     { "GetGUIDType", &LuaGlobalFunctions::GetGUIDType },
     { "GetGUIDEntry", &LuaGlobalFunctions::GetGUIDEntry },
     { "GetAreaName", &LuaGlobalFunctions::GetAreaName },
+    { "GetOwnerHalaa", &LuaGlobalFunctions::GetOwnerHalaa },
     { "bit_not", &LuaGlobalFunctions::bit_not },
     { "bit_xor", &LuaGlobalFunctions::bit_xor },
     { "bit_rshift", &LuaGlobalFunctions::bit_rshift },
@@ -148,6 +149,7 @@ luaL_Reg GlobalMethods[] =
     { "StartGameEvent", &LuaGlobalFunctions::StartGameEvent },
     { "StopGameEvent", &LuaGlobalFunctions::StopGameEvent },
     { "HttpRequest", &LuaGlobalFunctions::HttpRequest },
+    { "SetOwnerHalaa", &LuaGlobalFunctions::SetOwnerHalaa },
 
     { NULL, NULL }
 };


### PR DESCRIPTION
Co-authored by @r-o-b-o-t-o 

Adds new Global methods:
SetOwnerHalaa($teamId) //0=Alliance, 1 = Horde
GetOwnerHalaa() // returns { 0 or 1 for owner, $slider }

Tested with:
```lua
local function command( event, player, command, chathandler )
    if command == 'yx' then
        chathandler:SendSysMessage('SetOwnerHalaa(0)')
        SetOwnerHalaa(0)
    elseif command == 'as' then
            chathandler:SendSysMessage('SetOwnerHalaa(1)')
            SetOwnerHalaa(1)
    elseif command == 'qw' then
            chathandler:SendSysMessage('SetOwnerHalaa(2)')
            SetOwnerHalaa(2)
    elseif command == 'asdf' then
        local owner
        local slider
        owner, slider = GetOwnerHalaa()
        chathandler:SendSysMessage('GetOwnerHalaa(): '..owner..' slider: '..slider)
    end
    return false
end

RegisterPlayerEvent(42, command)
```