### PR TITLE
fix: modules ci build

### DIFF
--- a/src/LuaEngine/GlobalMethods.h
+++ b/src/LuaEngine/GlobalMethods.h
@@ -1229,7 +1229,7 @@ namespace LuaGlobalFunctions
     {
         const char* command = Eluna::CHECKVAL<const char*>(L, 1);
 #if defined TRINITY || AZEROTHCORE
-        eWorld->QueueCliCommand(new CliCommandHolder(nullptr, command, [](void* obj, std::string_view view)
+        eWorld->QueueCliCommand(new CliCommandHolder(nullptr, command, [](void*, std::string_view view)
         {
             std::string str = { view.begin(), view.end() };
             str.erase(std::find_if(str.rbegin(), str.rend(), [](unsigned char ch) { return !std::isspace(ch); }).base(), str.end()); // Remove trailing spaces and line breaks


### PR DESCRIPTION
Fixes the following build warning:
> In file included from /home/runner/work/azerothcore-wotlk/azerothcore-wotlk/modules/mod-eluna/src/LuaEngine/LuaFunctions.cpp:20:
/home/runner/work/azerothcore-wotlk/azerothcore-wotlk/modules/mod-eluna/src/LuaEngine/GlobalMethods.h:1232:81: fatal error: unused parameter 'obj' [-Wunused-parameter]
        eWorld->QueueCliCommand(new CliCommandHolder(nullptr, command, [](void* obj, std::string_view view)
                                                                                ^
1 error generated.