### PR TITLE
feat: add PLAYER_EVENT_ON_CAN_INIT_TRADE

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ Eluna API for AC:
 - Added `RegisterPlayerEvent` `45` (`PLAYER_ON_ACHIEVEMENT_COMPLETE`): https://github.com/azerothcore/mod-eluna/pull/47
 - Added `RegisterPlayerEvent` `46` (`PLAYER_EVENT_ON_FFAPVP_CHANGE`): https://github.com/azerothcore/mod-eluna/pull/63
 - Added `RegisterPlayerEvent` `47` (`PLAYER_EVENT_ON_UPDATE_AREA`): https://github.com/azerothcore/mod-eluna/pull/65
+- Added `RegisterPlayerEvent` `48` (`PLAYER_EVENT_ON_CAN_INIT_TRADE`): https://github.com/azerothcore/mod-eluna/pull/83
 - Added `Player:GetMailCount()`: https://github.com/azerothcore/mod-eluna/pull/76
 - Added `Player:GetXP()`: https://github.com/azerothcore/mod-eluna/pull/77
 - Added `Player:GetAchievementCriteriaProgress()`: https://github.com/azerothcore/mod-eluna/pull/78

--- a/src/ElunaLuaEngine_SC.cpp
+++ b/src/ElunaLuaEngine_SC.cpp
@@ -756,6 +756,11 @@ public:
     {
         sEluna->OnFfaPvpStateUpdate(player, IsFlaggedForFfaPvp);
     }
+
+    bool CanInitTrade(Player* player, Player* target) override
+    {
+        return sEluna->OnCanInitTrade(player, target);
+    }
 };
 
 class Eluna_ServerScript : public ServerScript

--- a/src/LuaEngine/GlobalMethods.h
+++ b/src/LuaEngine/GlobalMethods.h
@@ -713,6 +713,7 @@ namespace LuaGlobalFunctions
      *     PLAYER_EVENT_ON_ACHIEVEMENT_COMPLETE    =     45,       // (event, player, achievement)
      *     PLAYER_EVENT_ON_FFAPVP_CHANGE           =     46,       // (event, player, hasFfaPvp)
      *     PLAYER_EVENT_ON_UPDATE_AREA             =     47,       // (event, player, oldArea, newArea)
+     *     PLAYER_EVENT_ON_CAN_INIT_TRADE          =     48,       // (event, player, target) - Can return false to prevent the trade
      * };
      * </pre>
      *

--- a/src/LuaEngine/Hooks.h
+++ b/src/LuaEngine/Hooks.h
@@ -209,6 +209,7 @@ namespace Hooks
         PLAYER_EVENT_ON_ACHIEVEMENT_COMPLETE    =     45,       // (event, player, achievement)
         PLAYER_EVENT_ON_FFAPVP_CHANGE           =     46,       // (event, player, hasFfaPvp)
         PLAYER_EVENT_ON_UPDATE_AREA             =     47,       // (event, player, oldArea, newArea)
+        PLAYER_EVENT_ON_CAN_INIT_TRADE          =     48,       // (event, player, target) - Can return false to prevent the trade
 
         PLAYER_EVENT_COUNT
     };

--- a/src/LuaEngine/LuaEngine.h
+++ b/src/LuaEngine/LuaEngine.h
@@ -476,6 +476,7 @@ public:
     void OnLearnSpell(Player* player, uint32 spellId);
     void OnAchiComplete(Player* player, AchievementEntry const* achievement);
     void OnFfaPvpStateUpdate(Player* player, bool hasFfaPvp);
+    bool OnCanInitTrade(Player* player, Player* target);
 
 #ifndef CLASSIC
 #ifndef TBC

--- a/src/LuaEngine/PlayerHooks.cpp
+++ b/src/LuaEngine/PlayerHooks.cpp
@@ -584,11 +584,18 @@ void Eluna::OnAchiComplete(Player* player, AchievementEntry const* achievement)
     CallAllFunctions(PlayerEventBindings, key);
 }
 
-
 void Eluna::OnFfaPvpStateUpdate(Player* player, bool hasFfaPvp)
 {
     START_HOOK(PLAYER_EVENT_ON_FFAPVP_CHANGE);
     Push(player);
     Push(hasFfaPvp);
     CallAllFunctions(PlayerEventBindings, key);
+}
+
+bool Eluna::OnCanInitTrade(Player* player, Player* target)
+{
+    START_HOOK_WITH_RETVAL(PLAYER_EVENT_ON_CAN_INIT_TRADE, true);
+    Push(player);
+    Push(target);
+    return CallAllFunctionsBool(PlayerEventBindings, key);
 }


### PR DESCRIPTION
Adds a new `Player` event:
```cpp
PLAYER_EVENT_ON_CAN_INIT_TRADE = 48, // (event, player, target) - Can return false to prevent the trade
```

Example Lua snippet:
```lua
local PLAYER_EVENT_ON_CAN_INIT_TRADE = 48

local function OnTrade(event, player, target)
    print(player:GetName() .. " initiated a trade with " .. target:GetName())
    return false -- prevent the trade
end
RegisterPlayerEvent(PLAYER_EVENT_ON_CAN_INIT_TRADE, OnTrade)
```