### PR TITLE
feat: add ItemTemplate methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,12 @@ Eluna API for AC:
 ### Object
 - Added `Object:IsPlayer()`: https://github.com/azerothcore/mod-eluna/pull/42
 
+### Item
+- Added `Item:GetItemTemplate()`: https://github.com/azerothcore/mod-eluna/pull/84
+
 ### Misc
 - Added `HttpRequest()`: https://github.com/azerothcore/mod-eluna/pull/2
+- Added `GetItemTemplate(itemEntry)`: https://github.com/azerothcore/mod-eluna/pull/84
 - Added `ChatHandler` methods: https://github.com/azerothcore/mod-eluna/pull/23
+- Added `ItemTemplate` methods: https://github.com/azerothcore/mod-eluna/pull/84
 - Added logging with `ELUNA_LOG_INFO` for `RunCommand()`: https://github.com/azerothcore/mod-eluna/pull/75

--- a/src/LuaEngine/GlobalMethods.h
+++ b/src/LuaEngine/GlobalMethods.h
@@ -324,6 +324,13 @@ namespace LuaGlobalFunctions
         return 1;
     }
 
+    int GetItemTemplate(lua_State* L)
+    {
+        uint32 entry = Eluna::CHECKVAL<uint32>(L, 1);
+        Eluna::Push(L, eObjectMgr->GetItemTemplate(entry));
+        return 1;
+    }
+
     /**
      * Builds a [GameObject]'s GUID.
      *

--- a/src/LuaEngine/ItemMethods.h
+++ b/src/LuaEngine/ItemMethods.h
@@ -643,6 +643,17 @@ namespace LuaItem
     }
 
     /**
+     * Returns the [ItemTemplate] for this [Item].
+     *
+     * @return ItemTemplate itemTemplate
+     */
+    int GetItemTemplate(lua_State* L, Item* item)
+    {
+        Eluna::Push(L, item->GetTemplate());
+        return 1;
+    }
+
+    /**
      * Sets the [Player] specified as the owner of the [Item]
      *
      * @param [Player] player : the [Player] specified

--- a/src/LuaEngine/ItemTemplateMethods.h
+++ b/src/LuaEngine/ItemTemplateMethods.h
@@ -1,0 +1,191 @@
+/*
+* Copyright (C) 2010 - 2016 Eluna Lua Engine <http://emudevs.com/>
+* This program is free software licensed under GPL version 3
+* Please see the included DOCS/LICENSE.md for more information
+*/
+
+#ifndef ITEMTEMPLATEMETHODS_H
+#define ITEMTEMPLATEMETHODS_H
+
+#include "Chat.h"
+
+namespace LuaItemTemplate
+{
+    /**
+     * Returns the [ItemTemplate]'s ID.
+     *
+     * @return uint32 itemId
+     */
+    int GetItemId(lua_State* L, ItemTemplate* itemTemplate)
+    {
+        Eluna::Push(L, itemTemplate->ItemId);
+        return 1;
+    }
+
+    /**
+     * Returns the [ItemTemplate]'s class.
+     *
+     * @return uint32 class
+     */
+    int GetClass(lua_State* L, ItemTemplate* itemTemplate)
+    {
+        Eluna::Push(L, itemTemplate->Class);
+        return 1;
+    }
+
+    /**
+     * Returns the [ItemTemplate]'s subclass.
+     *
+     * @return uint32 subClass
+     */
+    int GetSubClass(lua_State* L, ItemTemplate* itemTemplate)
+    {
+        Eluna::Push(L, itemTemplate->SubClass);
+        return 1;
+    }
+
+    /**
+     * Returns the [ItemTemplate]'s name.
+     *
+     * @return string name
+     */
+    int GetName(lua_State* L, ItemTemplate* itemTemplate)
+    {
+        Eluna::Push(L, itemTemplate->Name1);
+        return 1;
+    }
+
+    /**
+     * Returns the [ItemTemplate]'s display ID.
+     *
+     * @return uint32 displayId
+     */
+    int GetDisplayId(lua_State* L, ItemTemplate* itemTemplate)
+    {
+        Eluna::Push(L, itemTemplate->DisplayInfoID);
+        return 1;
+    }
+
+    /**
+     * Returns the [ItemTemplate]'s quality.
+     *
+     * @return uint32 quality
+     */
+    int GetQuality(lua_State* L, ItemTemplate* itemTemplate)
+    {
+        Eluna::Push(L, itemTemplate->Quality);
+        return 1;
+    }
+
+    /**
+     * Returns the [ItemTemplate]'s flags.
+     *
+     * @return uint32 flags
+     */
+    int GetFlags(lua_State* L, ItemTemplate* itemTemplate)
+    {
+        Eluna::Push(L, itemTemplate->Flags);
+        return 1;
+    }
+
+    /**
+     * Returns the [ItemTemplate]'s extra flags.
+     *
+     * @return uint32 flags
+     */
+    int GetExtraFlags(lua_State* L, ItemTemplate* itemTemplate)
+    {
+        Eluna::Push(L, itemTemplate->Flags2);
+        return 1;
+    }
+
+    /**
+     * Returns the [ItemTemplate]'s default purchase count.
+     *
+     * @return uint32 buyCount
+     */
+    int GetBuyCount(lua_State* L, ItemTemplate* itemTemplate)
+    {
+        Eluna::Push(L, itemTemplate->BuyCount);
+        return 1;
+    }
+
+    /**
+     * Returns the [ItemTemplate]'s purchase price.
+     *
+     * @return int32 buyPrice
+     */
+    int GetBuyPrice(lua_State* L, ItemTemplate* itemTemplate)
+    {
+        Eluna::Push(L, itemTemplate->BuyPrice);
+        return 1;
+    }
+
+    /**
+     * Returns the [ItemTemplate]'s sell price.
+     *
+     * @return uint32 sellPrice
+     */
+    int GetSellPrice(lua_State* L, ItemTemplate* itemTemplate)
+    {
+        Eluna::Push(L, itemTemplate->SellPrice);
+        return 1;
+    }
+
+    /**
+     * Returns the [ItemTemplate]'s inventory type.
+     *
+     * @return uint32 inventoryType
+     */
+    int GetInventoryType(lua_State* L, ItemTemplate* itemTemplate)
+    {
+        Eluna::Push(L, itemTemplate->InventoryType);
+        return 1;
+    }
+
+    /**
+     * Returns the [Player] classes allowed to use this [ItemTemplate].
+     *
+     * @return uint32 allowableClass
+     */
+    int GetAllowableClass(lua_State* L, ItemTemplate* itemTemplate)
+    {
+        Eluna::Push(L, itemTemplate->AllowableClass);
+        return 1;
+    }
+
+    /**
+     * Returns the [Player] races allowed to use this [ItemTemplate].
+     *
+     * @return uint32 allowableRace
+     */
+    int GetAllowableRace(lua_State* L, ItemTemplate* itemTemplate)
+    {
+        Eluna::Push(L, itemTemplate->AllowableRace);
+        return 1;
+    }
+
+    /**
+     * Returns the [ItemTemplate]'s item level.
+     *
+     * @return uint32 itemLevel
+     */
+    int GetItemLevel(lua_State* L, ItemTemplate* itemTemplate)
+    {
+        Eluna::Push(L, itemTemplate->ItemLevel);
+        return 1;
+    }
+
+    /**
+     * Returns the minimum level required to use this [ItemTemplate].
+     *
+     * @return uint32 requiredLevel
+     */
+    int GetRequiredLevel(lua_State* L, ItemTemplate* itemTemplate)
+    {
+        Eluna::Push(L, itemTemplate->RequiredLevel);
+        return 1;
+    }
+}
+
+#endif

--- a/src/LuaEngine/LuaFunctions.cpp
+++ b/src/LuaEngine/LuaFunctions.cpp
@@ -38,6 +38,7 @@ extern "C"
 #include "BattleGroundMethods.h"
 #include "ChatHandlerMethods.h"
 #include "AchievementMethods.h"
+#include "ItemTemplateMethods.h"
 
 luaL_Reg GlobalMethods[] =
 {
@@ -92,6 +93,7 @@ luaL_Reg GlobalMethods[] =
     { "GetPlayerCount", &LuaGlobalFunctions::GetPlayerCount },
     { "GetPlayerGUID", &LuaGlobalFunctions::GetPlayerGUID },
     { "GetItemGUID", &LuaGlobalFunctions::GetItemGUID },
+    { "GetItemTemplate", &LuaGlobalFunctions::GetItemTemplate },
     { "GetObjectGUID", &LuaGlobalFunctions::GetObjectGUID },
     { "GetUnitGUID", &LuaGlobalFunctions::GetUnitGUID },
     { "GetGUIDLow", &LuaGlobalFunctions::GetGUIDLow },
@@ -961,6 +963,7 @@ ElunaRegister<Item> ItemMethods[] =
 #endif
     { "GetItemSet", &LuaItem::GetItemSet },
     { "GetBagSize", &LuaItem::GetBagSize },
+    { "GetItemTemplate", &LuaItem::GetItemTemplate },
 
     // Setters
     { "SetOwner", &LuaItem::SetOwner },
@@ -999,6 +1002,27 @@ ElunaRegister<Item> ItemMethods[] =
     // Other
     { "SaveToDB", &LuaItem::SaveToDB },
 
+    { NULL, NULL }
+};
+
+ElunaRegister<ItemTemplate> ItemTemplateMethods[] =
+{
+    { "GetItemId", &LuaItemTemplate::GetItemId },
+    { "GetClass", &LuaItemTemplate::GetClass },
+    { "GetSubClass", &LuaItemTemplate::GetSubClass },
+    { "GetName", &LuaItemTemplate::GetName },
+    { "GetDisplayId", &LuaItemTemplate::GetDisplayId },
+    { "GetQuality", &LuaItemTemplate::GetQuality },
+    { "GetFlags", &LuaItemTemplate::GetFlags },
+    { "GetExtraFlags", &LuaItemTemplate::GetExtraFlags },
+    { "GetBuyCount", &LuaItemTemplate::GetBuyCount },
+    { "GetBuyPrice", &LuaItemTemplate::GetBuyPrice },
+    { "GetSellPrice", &LuaItemTemplate::GetSellPrice },
+    { "GetInventoryType", &LuaItemTemplate::GetInventoryType },
+    { "GetAllowableClass", &LuaItemTemplate::GetAllowableClass },
+    { "GetAllowableRace", &LuaItemTemplate::GetAllowableRace },
+    { "GetItemLevel", &LuaItemTemplate::GetItemLevel },
+    { "GetRequiredLevel", &LuaItemTemplate::GetRequiredLevel },
     { NULL, NULL }
 };
 
@@ -1435,6 +1459,9 @@ void RegisterFunctions(Eluna* E)
     ElunaTemplate<Item>::Register(E, "Item");
     ElunaTemplate<Item>::SetMethods(E, ObjectMethods);
     ElunaTemplate<Item>::SetMethods(E, ItemMethods);
+
+    ElunaTemplate<ItemTemplate>::Register(E, "ItemTemplate");
+    ElunaTemplate<ItemTemplate>::SetMethods(E, ItemTemplateMethods);
 
 #ifndef CLASSIC
 #ifndef TBC


### PR DESCRIPTION
* Adds `GetItemTemplate(itemEntry)`
* Adds `Item:GetItemTemplate()`
* Adds `ItemTemplate` methods:
    * `ItemTemplate:GetItemId()`
    * `ItemTemplate:GetClass()`
    * `ItemTemplate:GetSubClass()`
    * `ItemTemplate:GetName()`
    * `ItemTemplate:GetDisplayId()`
    * `ItemTemplate:GetQuality()`
    * `ItemTemplate:GetFlags()`
    * `ItemTemplate:GetExtraFlags()`
    * `ItemTemplate:GetBuyCount()`
    * `ItemTemplate:GetBuyPrice()`
    * `ItemTemplate:GetSellPrice()`
    * `ItemTemplate:GetInventoryType()`
    * `ItemTemplate:GetAllowableClass()`
    * `ItemTemplate:GetAllowableRace()`
    * `ItemTemplate:GetItemLevel()`
    * `ItemTemplate:GetRequiredLevel()`
    Most of these methods are still accessible through the `Item` class to keep compatibility with existing scripts.