### PR TITLE
feat: add PLAYER_EVENT_ON_CAN_SEND_MAIL

### DIFF
--- a/src/ElunaLuaEngine_SC.cpp
+++ b/src/ElunaLuaEngine_SC.cpp
@@ -761,6 +761,11 @@ public:
     {
         return sEluna->OnCanInitTrade(player, target);
     }
+
+    bool CanSendMail(Player* player, ObjectGuid receiverGuid, ObjectGuid mailbox, std::string& subject, std::string& body, uint32 money, uint32 cod, Item* item) override
+    {
+        return sEluna->OnCanSendMail(player, receiverGuid, mailbox, subject, body, money, cod, item);
+    }
 };
 
 class Eluna_ServerScript : public ServerScript

--- a/src/LuaEngine/GlobalMethods.h
+++ b/src/LuaEngine/GlobalMethods.h
@@ -721,6 +721,7 @@ namespace LuaGlobalFunctions
      *     PLAYER_EVENT_ON_FFAPVP_CHANGE           =     46,       // (event, player, hasFfaPvp)
      *     PLAYER_EVENT_ON_UPDATE_AREA             =     47,       // (event, player, oldArea, newArea)
      *     PLAYER_EVENT_ON_CAN_INIT_TRADE          =     48,       // (event, player, target) - Can return false to prevent the trade
+     *     PLAYER_EVENT_ON_CAN_SEND_MAIL           =     49,       // (event, player, receiverGuid, mailbox, subject, body, money, cod, item) - Can return false to prevent sending the mail
      * };
      * </pre>
      *

--- a/src/LuaEngine/Hooks.h
+++ b/src/LuaEngine/Hooks.h
@@ -210,6 +210,7 @@ namespace Hooks
         PLAYER_EVENT_ON_FFAPVP_CHANGE           =     46,       // (event, player, hasFfaPvp)
         PLAYER_EVENT_ON_UPDATE_AREA             =     47,       // (event, player, oldArea, newArea)
         PLAYER_EVENT_ON_CAN_INIT_TRADE          =     48,       // (event, player, target) - Can return false to prevent the trade
+        PLAYER_EVENT_ON_CAN_SEND_MAIL           =     49,       // (event, player, receiverGuid, mailbox, subject, body, money, cod, item) - Can return false to prevent sending the mail
 
         PLAYER_EVENT_COUNT
     };

--- a/src/LuaEngine/LuaEngine.h
+++ b/src/LuaEngine/LuaEngine.h
@@ -477,6 +477,7 @@ public:
     void OnAchiComplete(Player* player, AchievementEntry const* achievement);
     void OnFfaPvpStateUpdate(Player* player, bool hasFfaPvp);
     bool OnCanInitTrade(Player* player, Player* target);
+    bool OnCanSendMail(Player* player, ObjectGuid receiverGuid, ObjectGuid mailbox, std::string& subject, std::string& body, uint32 money, uint32 cod, Item* item);
 
 #ifndef CLASSIC
 #ifndef TBC

--- a/src/LuaEngine/PlayerHooks.cpp
+++ b/src/LuaEngine/PlayerHooks.cpp
@@ -599,3 +599,17 @@ bool Eluna::OnCanInitTrade(Player* player, Player* target)
     Push(target);
     return CallAllFunctionsBool(PlayerEventBindings, key);
 }
+
+bool Eluna::OnCanSendMail(Player* player, ObjectGuid receiverGuid, ObjectGuid mailbox, std::string& subject, std::string& body, uint32 money, uint32 cod, Item* item)
+{
+    START_HOOK_WITH_RETVAL(PLAYER_EVENT_ON_CAN_SEND_MAIL, true);
+    Push(player);
+    Push(receiverGuid);
+    Push(mailbox);
+    Push(subject);
+    Push(body);
+    Push(money);
+    Push(cod);
+    Push(item);
+    return CallAllFunctionsBool(PlayerEventBindings, key);
+}


### PR DESCRIPTION
Adds a new `Player` event:
```cpp
PLAYER_EVENT_ON_CAN_SEND_MAIL = 49, // (event, player, receiverGuid, mailbox, subject, body, money, cod, item) - Can return false to prevent sending the mail
```

Example Lua snippet:
```lua
local PLAYER_EVENT_ON_CAN_SEND_MAIL = 49

local function OnSendMail(event, player, receiverGuid, mailbox, subject, body, money, cod, item)
	local receiver = GetPlayerByGUID(receiverGuid)
	if (receiver ~= nil) then
		print(player:GetName() .. " wants to send a mail to " .. receiver:GetName())
	else
		print(player:GetName() .. " wants to send a mail to " .. tostring(receiverGuid))
	end
	print("Subject: " .. subject)
	if money > 0 then
		print("Attached: " .. tostring(money) .. " copper")
	end
	if item ~= nil then
		print("Attached: " .. item:GetName())
	end
	if cod > 0 then
		print("COD: " .. tostring(cod) .. " copper")
	end
	print("Body:")
	print(body)

	return false -- prevent the mail from being sent
end
RegisterPlayerEvent(PLAYER_EVENT_ON_CAN_SEND_MAIL, OnSendMail)
```