### PR TITLE
feat: add PLAYER_EVENT_ON_CAN_JOIN_LFG

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Eluna API for AC:
 - Added `RegisterPlayerEvent` `47` (`PLAYER_EVENT_ON_UPDATE_AREA`): https://github.com/azerothcore/mod-eluna/pull/65
 - Added `RegisterPlayerEvent` `48` (`PLAYER_EVENT_ON_CAN_INIT_TRADE`): https://github.com/azerothcore/mod-eluna/pull/83
 - Added `RegisterPlayerEvent` `49` (`PLAYER_EVENT_ON_CAN_SEND_MAIL`): https://github.com/azerothcore/mod-eluna/pull/85
-- Added `RegisterPlayerEvent` `50` (`PLAYER_EVENT_ON_CAN_JOIN_LFG`): https://github.com/azerothcore/mod-eluna/pull/??
+- Added `RegisterPlayerEvent` `50` (`PLAYER_EVENT_ON_CAN_JOIN_LFG`): https://github.com/azerothcore/mod-eluna/pull/86
 - Added `Player:GetMailCount()`: https://github.com/azerothcore/mod-eluna/pull/76
 - Added `Player:GetXP()`: https://github.com/azerothcore/mod-eluna/pull/77
 - Added `Player:GetAchievementCriteriaProgress()`: https://github.com/azerothcore/mod-eluna/pull/78

--- a/README.md
+++ b/README.md
@@ -83,6 +83,8 @@ Eluna API for AC:
 - Added `RegisterPlayerEvent` `46` (`PLAYER_EVENT_ON_FFAPVP_CHANGE`): https://github.com/azerothcore/mod-eluna/pull/63
 - Added `RegisterPlayerEvent` `47` (`PLAYER_EVENT_ON_UPDATE_AREA`): https://github.com/azerothcore/mod-eluna/pull/65
 - Added `RegisterPlayerEvent` `48` (`PLAYER_EVENT_ON_CAN_INIT_TRADE`): https://github.com/azerothcore/mod-eluna/pull/83
+- Added `RegisterPlayerEvent` `49` (`PLAYER_EVENT_ON_CAN_SEND_MAIL`): https://github.com/azerothcore/mod-eluna/pull/85
+- Added `RegisterPlayerEvent` `50` (`PLAYER_EVENT_ON_CAN_JOIN_LFG`): https://github.com/azerothcore/mod-eluna/pull/??
 - Added `Player:GetMailCount()`: https://github.com/azerothcore/mod-eluna/pull/76
 - Added `Player:GetXP()`: https://github.com/azerothcore/mod-eluna/pull/77
 - Added `Player:GetAchievementCriteriaProgress()`: https://github.com/azerothcore/mod-eluna/pull/78

--- a/src/ElunaLuaEngine_SC.cpp
+++ b/src/ElunaLuaEngine_SC.cpp
@@ -766,6 +766,11 @@ public:
     {
         return sEluna->OnCanSendMail(player, receiverGuid, mailbox, subject, body, money, cod, item);
     }
+
+    bool CanJoinLfg(Player* player, uint8 roles, lfg::LfgDungeonSet& dungeons, const std::string& comment) override
+    {
+        return sEluna->OnCanJoinLfg(player, roles, dungeons, comment);
+    }
 };
 
 class Eluna_ServerScript : public ServerScript

--- a/src/LuaEngine/GlobalMethods.h
+++ b/src/LuaEngine/GlobalMethods.h
@@ -722,6 +722,7 @@ namespace LuaGlobalFunctions
      *     PLAYER_EVENT_ON_UPDATE_AREA             =     47,       // (event, player, oldArea, newArea)
      *     PLAYER_EVENT_ON_CAN_INIT_TRADE          =     48,       // (event, player, target) - Can return false to prevent the trade
      *     PLAYER_EVENT_ON_CAN_SEND_MAIL           =     49,       // (event, player, receiverGuid, mailbox, subject, body, money, cod, item) - Can return false to prevent sending the mail
+     *     PLAYER_EVENT_ON_CAN_JOIN_LFG            =     50,       // (event, player, roles, dungeons, comment) - Can return false to prevent queueing
      * };
      * </pre>
      *

--- a/src/LuaEngine/Hooks.h
+++ b/src/LuaEngine/Hooks.h
@@ -211,6 +211,7 @@ namespace Hooks
         PLAYER_EVENT_ON_UPDATE_AREA             =     47,       // (event, player, oldArea, newArea)
         PLAYER_EVENT_ON_CAN_INIT_TRADE          =     48,       // (event, player, target) - Can return false to prevent the trade
         PLAYER_EVENT_ON_CAN_SEND_MAIL           =     49,       // (event, player, receiverGuid, mailbox, subject, body, money, cod, item) - Can return false to prevent sending the mail
+        PLAYER_EVENT_ON_CAN_JOIN_LFG            =     50,       // (event, player, roles, dungeons, comment) - Can return false to prevent queueing
 
         PLAYER_EVENT_COUNT
     };

--- a/src/LuaEngine/LuaEngine.h
+++ b/src/LuaEngine/LuaEngine.h
@@ -20,6 +20,7 @@
 #include "Weather.h"
 #include "World.h"
 #include "Hooks.h"
+#include "LFG.h"
 #include "ElunaUtility.h"
 #include "HttpManager.h"
 #include <mutex>
@@ -478,6 +479,7 @@ public:
     void OnFfaPvpStateUpdate(Player* player, bool hasFfaPvp);
     bool OnCanInitTrade(Player* player, Player* target);
     bool OnCanSendMail(Player* player, ObjectGuid receiverGuid, ObjectGuid mailbox, std::string& subject, std::string& body, uint32 money, uint32 cod, Item* item);
+    bool OnCanJoinLfg(Player* player, uint8 roles, lfg::LfgDungeonSet& dungeons, const std::string& comment);
 
 #ifndef CLASSIC
 #ifndef TBC

--- a/src/LuaEngine/PlayerHooks.cpp
+++ b/src/LuaEngine/PlayerHooks.cpp
@@ -613,3 +613,25 @@ bool Eluna::OnCanSendMail(Player* player, ObjectGuid receiverGuid, ObjectGuid ma
     Push(item);
     return CallAllFunctionsBool(PlayerEventBindings, key);
 }
+
+bool Eluna::OnCanJoinLfg(Player* player, uint8 roles, lfg::LfgDungeonSet& dungeons, const std::string& comment)
+{
+    START_HOOK_WITH_RETVAL(PLAYER_EVENT_ON_CAN_JOIN_LFG, true);
+    Push(player);
+    Push(roles);
+
+    lua_newtable(L);
+    int table = lua_gettop(L);
+    uint32 counter = 1;
+    for (uint32 dungeon : dungeons)
+    {
+        Eluna::Push(L, dungeon);
+        lua_rawseti(L, table, counter);
+        ++counter;
+    }
+    lua_settop(L, table);
+    ++push_counter;
+
+    Push(comment);
+    return CallAllFunctionsBool(PlayerEventBindings, key);
+}


### PR DESCRIPTION
Adds a new `Player` event:
```cpp
PLAYER_EVENT_ON_CAN_JOIN_LFG = 50, // (event, player, roles, dungeons, comment) - Can return false to prevent queueing
```

Example Lua snippet:
```lua
local PLAYER_EVENT_ON_CAN_JOIN_LFG = 50

RegisterPlayerEvent(PLAYER_EVENT_ON_CAN_JOIN_LFG, function(event, player, roles, dungeons, comment)
	print("Player: " .. player:GetName())
	print("Roles: " .. tostring(roles))
	print("Dungeons:")
	for i = 1, #dungeons do
		print(dungeons[i])
	end
	if (comment ~= nil) then
		print("Comment: " .. comment)
	end

	return false -- prevent queueing
end)
```