### PR TITLE
feat: add PLAYER_EVENT_ON_COMPLETE_QUEST

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ Eluna API for AC:
 - Added `RegisterPlayerEvent` `51` (`PLAYER_EVENT_ON_QUEST_REWARD_ITEM`): https://github.com/azerothcore/mod-eluna/pull/88
 - Added `RegisterPlayerEvent` `52` (`PLAYER_EVENT_ON_CREATE_ITEM`): https://github.com/azerothcore/mod-eluna/pull/88
 - Added `RegisterPlayerEvent` `53` (`PLAYER_EVENT_ON_STORE_NEW_ITEM`): https://github.com/azerothcore/mod-eluna/pull/88
+- Added `RegisterPlayerEvent` `54` (`PLAYER_EVENT_ON_COMPLETE_QUEST`): https://github.com/azerothcore/mod-eluna/pull/??
 - Added `Player:GetMailCount()`: https://github.com/azerothcore/mod-eluna/pull/76
 - Added `Player:GetXP()`: https://github.com/azerothcore/mod-eluna/pull/77
 - Added `Player:GetAchievementCriteriaProgress()`: https://github.com/azerothcore/mod-eluna/pull/78

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ Eluna API for AC:
 - Added `RegisterPlayerEvent` `51` (`PLAYER_EVENT_ON_QUEST_REWARD_ITEM`): https://github.com/azerothcore/mod-eluna/pull/88
 - Added `RegisterPlayerEvent` `52` (`PLAYER_EVENT_ON_CREATE_ITEM`): https://github.com/azerothcore/mod-eluna/pull/88
 - Added `RegisterPlayerEvent` `53` (`PLAYER_EVENT_ON_STORE_NEW_ITEM`): https://github.com/azerothcore/mod-eluna/pull/88
-- Added `RegisterPlayerEvent` `54` (`PLAYER_EVENT_ON_COMPLETE_QUEST`): https://github.com/azerothcore/mod-eluna/pull/??
+- Added `RegisterPlayerEvent` `54` (`PLAYER_EVENT_ON_COMPLETE_QUEST`): https://github.com/azerothcore/mod-eluna/pull/90
 - Added `Player:GetMailCount()`: https://github.com/azerothcore/mod-eluna/pull/76
 - Added `Player:GetXP()`: https://github.com/azerothcore/mod-eluna/pull/77
 - Added `Player:GetAchievementCriteriaProgress()`: https://github.com/azerothcore/mod-eluna/pull/78

--- a/README_CN.md
+++ b/README_CN.md
@@ -87,5 +87,6 @@ AC版的Eluna API:
 - 添加玩家注册事件51(当玩家获得任务奖励时) `PLAYER_EVENT_ON_QUEST_REWARD_ITEM`。https://github.com/azerothcore/mod-eluna/pull/88
 - 添加玩家注册事件52(当玩家创建物品时) `PLAYER_EVENT_ON_CREATE_ITEM`。https://github.com/azerothcore/mod-eluna/pull/88
 - 添加玩家注册事件53(当玩家创建物品实例时) `PLAYER_EVENT_ON_STORE_NEW_ITEM`。https://github.com/azerothcore/mod-eluna/pull/88
+- 添加玩家注册事件54(当玩家完成任务时) `PLAYER_EVENT_ON_COMPLETE_QUEST`。https://github.com/azerothcore/mod-eluna/pull/??
 - 新增参数*商人Id*到方法player:SendListInventory(object, vendorentry)中。 https://github.com/azerothcore/mod-eluna/pull/48
 - 添加方法`gameobject:AddLoot()`, 可以在线给**空**的容器中添加战利品。 https://github.com/azerothcore/mod-eluna/pull/52

--- a/README_CN.md
+++ b/README_CN.md
@@ -87,6 +87,6 @@ AC版的Eluna API:
 - 添加玩家注册事件51(当玩家获得任务奖励时) `PLAYER_EVENT_ON_QUEST_REWARD_ITEM`。https://github.com/azerothcore/mod-eluna/pull/88
 - 添加玩家注册事件52(当玩家创建物品时) `PLAYER_EVENT_ON_CREATE_ITEM`。https://github.com/azerothcore/mod-eluna/pull/88
 - 添加玩家注册事件53(当玩家创建物品实例时) `PLAYER_EVENT_ON_STORE_NEW_ITEM`。https://github.com/azerothcore/mod-eluna/pull/88
-- 添加玩家注册事件54(当玩家完成任务时) `PLAYER_EVENT_ON_COMPLETE_QUEST`。https://github.com/azerothcore/mod-eluna/pull/??
+- 添加玩家注册事件54(当玩家完成任务时) `PLAYER_EVENT_ON_COMPLETE_QUEST`。https://github.com/azerothcore/mod-eluna/pull/90
 - 新增参数*商人Id*到方法player:SendListInventory(object, vendorentry)中。 https://github.com/azerothcore/mod-eluna/pull/48
 - 添加方法`gameobject:AddLoot()`, 可以在线给**空**的容器中添加战利品。 https://github.com/azerothcore/mod-eluna/pull/52

--- a/src/ElunaLuaEngine_SC.cpp
+++ b/src/ElunaLuaEngine_SC.cpp
@@ -786,6 +786,11 @@ public:
     {
         sEluna->OnStoreNewItem(player, item, count);
     }
+
+    void OnPlayerCompleteQuest(Player* player, Quest const* quest) override
+    {
+        sEluna->OnPlayerCompleteQuest(player, quest);
+    }
 };
 
 class Eluna_ServerScript : public ServerScript

--- a/src/LuaEngine/GlobalMethods.h
+++ b/src/LuaEngine/GlobalMethods.h
@@ -723,9 +723,10 @@ namespace LuaGlobalFunctions
      *     PLAYER_EVENT_ON_CAN_INIT_TRADE          =     48,       // (event, player, target) - Can return false to prevent the trade
      *     PLAYER_EVENT_ON_CAN_SEND_MAIL           =     49,       // (event, player, receiverGuid, mailbox, subject, body, money, cod, item) - Can return false to prevent sending the mail
      *     PLAYER_EVENT_ON_CAN_JOIN_LFG            =     50,       // (event, player, roles, dungeons, comment) - Can return false to prevent queueing
-     *     PLAYER_EVENT_ON_QUEST_REWARD_ITEM            =     51,       //  (event, player, item, count)
-     *     PLAYER_EVENT_ON_CREATE_ITEM            =     52,       //  (event, player, item, count)
-     *     PLAYER_EVENT_ON_STORE_NEW_ITEM            =     53,       //  (event, player, item, count)
+     *     PLAYER_EVENT_ON_QUEST_REWARD_ITEM       =     51,       //  (event, player, item, count)
+     *     PLAYER_EVENT_ON_CREATE_ITEM             =     52,       //  (event, player, item, count)
+     *     PLAYER_EVENT_ON_STORE_NEW_ITEM          =     53,       //  (event, player, item, count)
+     *     PLAYER_EVENT_ON_COMPLETE_QUEST          =     54,       // (event, player, quest)
      * };
      * </pre>
      *

--- a/src/LuaEngine/Hooks.h
+++ b/src/LuaEngine/Hooks.h
@@ -215,6 +215,7 @@ namespace Hooks
         PLAYER_EVENT_ON_QUEST_REWARD_ITEM       =     51,       // (event, player, item, count)
         PLAYER_EVENT_ON_CREATE_ITEM             =     52,       // (event, player, item, count)
         PLAYER_EVENT_ON_STORE_NEW_ITEM          =     53,       // (event, player, item, count) 
+        PLAYER_EVENT_ON_COMPLETE_QUEST          =     54,       // (event, player, quest) 
 
         PLAYER_EVENT_COUNT
     };

--- a/src/LuaEngine/LuaEngine.h
+++ b/src/LuaEngine/LuaEngine.h
@@ -373,6 +373,7 @@ public:
     void OnQuestRewardItem(Player* player, Item* item, uint32 count);
     void OnCreateItem(Player* player, Item* item, uint32 count);
     void OnStoreNewItem(Player* player, Item* item, uint32 count);
+    void OnPlayerCompleteQuest(Player* player, Quest const* quest);
 
     /* Item */
     void OnDummyEffect(WorldObject* pCaster, uint32 spellId, SpellEffIndex effIndex, Item* pTarget);

--- a/src/LuaEngine/PlayerHooks.cpp
+++ b/src/LuaEngine/PlayerHooks.cpp
@@ -662,3 +662,11 @@ void Eluna::OnStoreNewItem(Player* player, Item* item, uint32 count)
     Push(count);
     CallAllFunctions(PlayerEventBindings, key);
 }
+
+void Eluna::OnPlayerCompleteQuest(Player* player, Quest const* quest)
+{
+    START_HOOK(PLAYER_EVENT_ON_COMPLETE_QUEST);
+    Push(player);
+    Push(quest);
+    CallAllFunctions(PlayerEventBindings, key);
+}


### PR DESCRIPTION

Adds a new Player event:

PLAYER_EVENT_ON_COMPLETE_QUEST = 54, // (event, player, quest)
Example Lua snippet:

local PLAYER_EVENT_ON_COMPLETE_QUEST = 54

RegisterPlayerEvent(PLAYER_EVENT_ON_COMPLETE_QUEST, function(event, player, quest)
	print("Player: " .. player:GetName())
	print("QuestID: " .. quest:GetId())
end)