### PR TITLE
feat: add PLAYER_EVENT_ON_CAN_GROUP_INVITE

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ Eluna API for AC:
 - Added `RegisterPlayerEvent` `52` (`PLAYER_EVENT_ON_CREATE_ITEM`): https://github.com/azerothcore/mod-eluna/pull/88
 - Added `RegisterPlayerEvent` `53` (`PLAYER_EVENT_ON_STORE_NEW_ITEM`): https://github.com/azerothcore/mod-eluna/pull/88
 - Added `RegisterPlayerEvent` `54` (`PLAYER_EVENT_ON_COMPLETE_QUEST`): https://github.com/azerothcore/mod-eluna/pull/90
+- Added `RegisterPlayerEvent` `55` (`PLAYER_EVENT_ON_CAN_GROUP_INVITE`): https://github.com/azerothcore/mod-eluna/pull/100
 - Added `Player:GetMailCount()`: https://github.com/azerothcore/mod-eluna/pull/76
 - Added `Player:GetXP()`: https://github.com/azerothcore/mod-eluna/pull/77
 - Added `Player:GetAchievementCriteriaProgress()`: https://github.com/azerothcore/mod-eluna/pull/78

--- a/src/ElunaLuaEngine_SC.cpp
+++ b/src/ElunaLuaEngine_SC.cpp
@@ -791,6 +791,11 @@ public:
     {
         sEluna->OnPlayerCompleteQuest(player, quest);
     }
+
+    bool CanGroupInvite(Player* player, std::string& memberName) override
+    {
+        return sEluna->OnCanGroupInvite(player, memberName);
+    }
 };
 
 class Eluna_ServerScript : public ServerScript

--- a/src/LuaEngine/GlobalMethods.h
+++ b/src/LuaEngine/GlobalMethods.h
@@ -727,6 +727,7 @@ namespace LuaGlobalFunctions
      *     PLAYER_EVENT_ON_CREATE_ITEM             =     52,       //  (event, player, item, count)
      *     PLAYER_EVENT_ON_STORE_NEW_ITEM          =     53,       //  (event, player, item, count)
      *     PLAYER_EVENT_ON_COMPLETE_QUEST          =     54,       // (event, player, quest)
+     *     PLAYER_EVENT_ON_CAN_GROUP_INVITE        =     55,       // (event, player, memberName) - Can return false to prevent inviting
      * };
      * </pre>
      *

--- a/src/LuaEngine/Hooks.h
+++ b/src/LuaEngine/Hooks.h
@@ -215,7 +215,8 @@ namespace Hooks
         PLAYER_EVENT_ON_QUEST_REWARD_ITEM       =     51,       // (event, player, item, count)
         PLAYER_EVENT_ON_CREATE_ITEM             =     52,       // (event, player, item, count)
         PLAYER_EVENT_ON_STORE_NEW_ITEM          =     53,       // (event, player, item, count) 
-        PLAYER_EVENT_ON_COMPLETE_QUEST          =     54,       // (event, player, quest) 
+        PLAYER_EVENT_ON_COMPLETE_QUEST          =     54,       // (event, player, quest)
+        PLAYER_EVENT_ON_CAN_GROUP_INVITE        =     55,       // (event, player, memberName) - Can return false to prevent inviting
 
         PLAYER_EVENT_COUNT
     };

--- a/src/LuaEngine/LuaEngine.h
+++ b/src/LuaEngine/LuaEngine.h
@@ -484,6 +484,7 @@ public:
     bool OnCanInitTrade(Player* player, Player* target);
     bool OnCanSendMail(Player* player, ObjectGuid receiverGuid, ObjectGuid mailbox, std::string& subject, std::string& body, uint32 money, uint32 cod, Item* item);
     bool OnCanJoinLfg(Player* player, uint8 roles, lfg::LfgDungeonSet& dungeons, const std::string& comment);
+    bool OnCanGroupInvite(Player* player, std::string& memberName);
 
 #ifndef CLASSIC
 #ifndef TBC

--- a/src/LuaEngine/PlayerHooks.cpp
+++ b/src/LuaEngine/PlayerHooks.cpp
@@ -670,3 +670,11 @@ void Eluna::OnPlayerCompleteQuest(Player* player, Quest const* quest)
     Push(quest);
     CallAllFunctions(PlayerEventBindings, key);
 }
+
+bool Eluna::OnCanGroupInvite(Player* player, std::string& memberName)
+{
+    START_HOOK_WITH_RETVAL(PLAYER_EVENT_ON_CAN_GROUP_INVITE, true);
+    Push(player);
+    Push(memberName);
+    return CallAllFunctionsBool(PlayerEventBindings, key);
+}


### PR DESCRIPTION
Adds a new `Player` event:
```cpp
PLAYER_EVENT_ON_CAN_GROUP_INVITE = 55 // (event, player, memberName) - Can return false to prevent inviting
```

Example Lua snippet:
```lua
local PLAYER_EVENT_ON_CAN_GROUP_INVITE = 55

RegisterPlayerEvent(PLAYER_EVENT_ON_CAN_GROUP_INVITE, function(event, player, newMemberName)
	print("Player: " .. player:GetName())
	print("Invited: " .. newMemberName)

	return false -- prevent inviting
end)
```