### PR TITLE
Fix player timed events not carrying over between maps

### DIFF
--- a/src/ElunaLuaEngine_SC.cpp
+++ b/src/ElunaLuaEngine_SC.cpp
@@ -901,16 +901,8 @@ public:
 
     void OnWorldObjectSetMap(WorldObject* object, Map* /*map*/) override
     {
-        delete object->elunaEvents;
-
-        // On multithread replace this with a pointer to map's Eluna pointer stored in a map
-        object->elunaEvents = new ElunaEventProcessor(&Eluna::GEluna, object);
-    }
-
-    void OnWorldObjectResetMap(WorldObject* object) override
-    {
-        delete object->elunaEvents;
-        object->elunaEvents = nullptr;
+        if (!object->elunaEvents)
+            object->elunaEvents = new ElunaEventProcessor(&Eluna::GEluna, object);
     }
 
     void OnWorldObjectUpdate(WorldObject* object, uint32 diff) override


### PR DESCRIPTION
Timed events tied to players are removed when a player teleports from one map to another.

In this PR we change it so that timed evens are no longer removed.

See
* https://github.com/ElunaLuaEngine/ElunaTrinityWotlk/commit/a0d10f8ff0e68cf59cd7b2fd62e985adaeb35d9d
* https://discord.com/channels/817077195817353226/1074254244561031248/1074254244561031248