### PR TITLE
fix(ci): exclude date.js from doc PR git status

### DIFF
--- a/.github/workflows/create-pr.sh
+++ b/.github/workflows/create-pr.sh
@@ -23,7 +23,7 @@ cp -r "$SOURCE_FOLDER/." "$CLONE_DIR/$DESTINATION_FOLDER/"
 
 echo "Adding files"
 git add .
-if git status | grep -q "Changes to be committed"
+if git status -- ":!date.js" | grep -q "Changes to be committed"
 then
   echo "Adding git commit"
   git commit -m "$COMMIT_MESSAGE"


### PR DESCRIPTION
This will prevent creating "empty" PRs when only the date changes, ie. https://github.com/azerothcore/azerothcore.github.io/commit/9f62d5bbab73fd0eb67e60b3d859fd348b54584b