### PR TITLE
fix: Include new parameter for OnGiveXP hook.

### DIFF
--- a/src/ElunaLuaEngine_SC.cpp
+++ b/src/ElunaLuaEngine_SC.cpp
@@ -657,9 +657,9 @@ public:
         sEluna->OnMoneyChanged(player, amount);
     }
 
-    void OnGiveXP(Player* player, uint32& amount, Unit* victim) override
+    void OnGiveXP(Player* player, uint32& amount, Unit* victim, uint8 xpSource) override
     {
-        sEluna->OnGiveXP(player, amount, victim);
+        sEluna->OnGiveXP(player, amount, victim, xpSource);
     }
 
     bool OnReputationChange(Player* player, uint32 factionID, int32& standing, bool incremental) override

--- a/src/LuaEngine/Hooks.h
+++ b/src/LuaEngine/Hooks.h
@@ -171,7 +171,7 @@ namespace Hooks
         PLAYER_EVENT_ON_DUEL_REQUEST            =     9,        // (event, target, challenger)
         PLAYER_EVENT_ON_DUEL_START              =     10,       // (event, player1, player2)
         PLAYER_EVENT_ON_DUEL_END                =     11,       // (event, winner, loser, type)
-        PLAYER_EVENT_ON_GIVE_XP                 =     12,       // (event, player, amount, victim) - Can return new XP amount
+        PLAYER_EVENT_ON_GIVE_XP                 =     12,       // (event, player, amount, victim, source) - Can return new XP amount
         PLAYER_EVENT_ON_LEVEL_CHANGE            =     13,       // (event, player, oldLevel)
         PLAYER_EVENT_ON_MONEY_CHANGE            =     14,       // (event, player, amount) - Can return new money amount
         PLAYER_EVENT_ON_REPUTATION_CHANGE       =     15,       // (event, player, factionId, standing, incremental) - Can return new standing -> if standing == -1, it will prevent default action (rep gain)

--- a/src/LuaEngine/LuaEngine.h
+++ b/src/LuaEngine/LuaEngine.h
@@ -456,7 +456,7 @@ public:
     void OnFreeTalentPointsChanged(Player* pPlayer, uint32 newPoints);
     void OnTalentsReset(Player* pPlayer, bool noCost);
     void OnMoneyChanged(Player* pPlayer, int32& amount);
-    void OnGiveXP(Player* pPlayer, uint32& amount, Unit* pVictim);
+    void OnGiveXP(Player* pPlayer, uint32& amount, Unit* pVictim, uint8 xpSource);
     bool OnReputationChange(Player* pPlayer, uint32 factionID, int32& standing, bool incremental);
     void OnDuelRequest(Player* pTarget, Player* pChallenger);
     void OnDuelStart(Player* pStarter, Player* pChallenger);

--- a/src/LuaEngine/PlayerHooks.cpp
+++ b/src/LuaEngine/PlayerHooks.cpp
@@ -227,18 +227,19 @@ void Eluna::OnMoneyChanged(Player* pPlayer, int32& amount)
     CleanUpStack(2);
 }
 
-void Eluna::OnGiveXP(Player* pPlayer, uint32& amount, Unit* pVictim)
+void Eluna::OnGiveXP(Player* pPlayer, uint32& amount, Unit* pVictim, uint8 xpSource)
 {
     START_HOOK(PLAYER_EVENT_ON_GIVE_XP);
     Push(pPlayer);
     Push(amount);
     Push(pVictim);
+    Push(xpSource);
     int amountIndex = lua_gettop(L) - 1;
-    int n = SetupStack(PlayerEventBindings, key, 3);
+    int n = SetupStack(PlayerEventBindings, key, 4);
 
     while (n > 0)
     {
-        int r = CallOneFunction(n--, 3, 1);
+        int r = CallOneFunction(n--, 4, 1);
 
         if (lua_isnumber(L, r))
         {
@@ -250,7 +251,7 @@ void Eluna::OnGiveXP(Player* pPlayer, uint32& amount, Unit* pVictim)
         lua_pop(L, 1);
     }
 
-    CleanUpStack(3);
+    CleanUpStack(4);
 }
 
 bool Eluna::OnReputationChange(Player* pPlayer, uint32 factionID, int32& standing, bool incremental)


### PR DESCRIPTION
### Description
Includes the new XPSource parameter for the OnGiveXP hook.

This PR should only be merged when the core PR is merged.

### Issues
https://github.com/azerothcore/azerothcore-wotlk/pull/16109

### Testing
- Create ./lua_scripts/TestXPHook.lua
```lua
local PLAYER_EVENT_ON_GIVE_XP = 12

xpMap = {}
xpMap[0] = "Kill"
xpMap[1] = "Quest"
xpMap[2] = "Dungeon Finder"
xpMap[3] = "Explore"
xpMap[4] = "Battleground"

local function OnGiveXP(event, player, amount, victim, source)
    player:SendBroadcastMessage("Received XP from: " .. xpMap[source])
end

RegisterPlayerEvent(PLAYER_EVENT_ON_GIVE_XP, OnGiveXP)
```