### PR TITLE
Fix crash caused by VendorRemoveAllItems

### DIFF
--- a/src/LuaEngine/GlobalMethods.h
+++ b/src/LuaEngine/GlobalMethods.h
@@ -2061,7 +2061,7 @@ namespace LuaGlobalFunctions
             return 0;
 
         auto const& itemlist = items->m_items;
-        for (auto itr = itemlist.begin(); itr != itemlist.end(); ++itr)
+        for (auto itr = itemlist.rbegin(); itr != itemlist.rend(); ++itr)
 #if defined(CATA) || defined(MISTS)
             eObjectMgr->RemoveVendorItem(entry, (*itr)->item, 1);
 #else


### PR DESCRIPTION
VendorRemoveAllItems deletes while traversing, causing the iterator itr to fail, which causes the worldserver to crash.