### PR TITLE
Add Method to Player: SetGlyph

### DIFF
--- a/src/LuaEngine/LuaFunctions.cpp
+++ b/src/LuaEngine/LuaFunctions.cpp
@@ -689,7 +689,7 @@ ElunaRegister<Player> PlayerMethods[] =
     { "ModifyMoney", &LuaPlayer::ModifyMoney },
     { "LearnSpell", &LuaPlayer::LearnSpell },
     { "LearnTalent", &LuaPlayer::LearnTalent },
-    {"SetGlyph",&LuaPlayer::SetGlyph},
+    { "SetGlyph", &LuaPlayer::SetGlyph },
 #if !defined(CLASSIC)
     { "RemoveArenaSpellCooldowns", &LuaPlayer::RemoveArenaSpellCooldowns },
 #endif

--- a/src/LuaEngine/LuaFunctions.cpp
+++ b/src/LuaEngine/LuaFunctions.cpp
@@ -689,6 +689,7 @@ ElunaRegister<Player> PlayerMethods[] =
     { "ModifyMoney", &LuaPlayer::ModifyMoney },
     { "LearnSpell", &LuaPlayer::LearnSpell },
     { "LearnTalent", &LuaPlayer::LearnTalent },
+    {"AddGlyph",&LuaPlayer::AddGlyph},
 #if !defined(CLASSIC)
     { "RemoveArenaSpellCooldowns", &LuaPlayer::RemoveArenaSpellCooldowns },
 #endif

--- a/src/LuaEngine/LuaFunctions.cpp
+++ b/src/LuaEngine/LuaFunctions.cpp
@@ -689,7 +689,7 @@ ElunaRegister<Player> PlayerMethods[] =
     { "ModifyMoney", &LuaPlayer::ModifyMoney },
     { "LearnSpell", &LuaPlayer::LearnSpell },
     { "LearnTalent", &LuaPlayer::LearnTalent },
-    {"AddGlyph",&LuaPlayer::AddGlyph},
+    {"SetGlyph",&LuaPlayer::SetGlyph},
 #if !defined(CLASSIC)
     { "RemoveArenaSpellCooldowns", &LuaPlayer::RemoveArenaSpellCooldowns },
 #endif

--- a/src/LuaEngine/PlayerMethods.h
+++ b/src/LuaEngine/PlayerMethods.h
@@ -3845,7 +3845,7 @@ namespace LuaPlayer
         uint32 glyphId = Eluna::CHECKVAL<uint32>(L, 2);
         uint32 slotIndex = Eluna::CHECKVAL<uint32>(L, 3);
 
-        player->SetGlyph(slot_index, glyph_id, !player->GetSession()->PlayerLoading());
+        player->SetGlyph(slotIndex, glyphId, !player->GetSession()->PlayerLoading());
         #if (!defined(TBC) && !defined(CLASSIC))
             player->SendTalentsInfoData(false); //Also handles GlyphData
         #endif

--- a/src/LuaEngine/PlayerMethods.h
+++ b/src/LuaEngine/PlayerMethods.h
@@ -3837,8 +3837,8 @@ namespace LuaPlayer
     /**
     * Adds a glyph specified by `glyphId` to the [Player]'s current talent specialization into the slot with the index `slotIndex`
     *
-    * @param uint32 glyph_id
-    * @param uint32 slot_index
+    * @param uint32 glyphId
+    * @param uint32 slotIndex
     */
     int SetGlyph(lua_State* L, Player* player)
     {

--- a/src/LuaEngine/PlayerMethods.h
+++ b/src/LuaEngine/PlayerMethods.h
@@ -3845,10 +3845,8 @@ namespace LuaPlayer
         uint32 glyphId = Eluna::CHECKVAL<uint32>(L, 2);
         uint32 slotIndex = Eluna::CHECKVAL<uint32>(L, 3);
 
-        player->SetGlyph(slotIndex, glyphId, !player->GetSession()->PlayerLoading());
-        #if (!defined(TBC) && !defined(CLASSIC))
-            player->SendTalentsInfoData(false); // Also handles GlyphData
-        #endif
+        player->SetGlyph(slotIndex, glyphId, true);
+        player->SendTalentsInfoData(false); // Also handles GlyphData
 
         return 0;
     }

--- a/src/LuaEngine/PlayerMethods.h
+++ b/src/LuaEngine/PlayerMethods.h
@@ -3835,7 +3835,7 @@ namespace LuaPlayer
     }
 
     /**
-    * Add the [Player] the Glyph specified by glyph_id into the slot specified by slot_index into current talentGroup/Spec
+    * Adds a glyph specified by `glyphId` to the [Player]'s current talent specialization into the slot with the index `slotIndex`
     *
     * @param uint32 glyph_id
     * @param uint32 slot_index

--- a/src/LuaEngine/PlayerMethods.h
+++ b/src/LuaEngine/PlayerMethods.h
@@ -3847,7 +3847,7 @@ namespace LuaPlayer
 
         player->SetGlyph(slotIndex, glyphId, !player->GetSession()->PlayerLoading());
         #if (!defined(TBC) && !defined(CLASSIC))
-            player->SendTalentsInfoData(false); //Also handles GlyphData
+            player->SendTalentsInfoData(false); // Also handles GlyphData
         #endif
 
         return 0;

--- a/src/LuaEngine/PlayerMethods.h
+++ b/src/LuaEngine/PlayerMethods.h
@@ -3834,6 +3834,25 @@ namespace LuaPlayer
         return 0;
     }
 
+    /**
+    * Add the [Player] the Glyph specified by glyph_id into the slot specified by slot_index into current talentGroup/Spec
+    *
+    * @param uint32 glyph_id
+    * @param uint32 slot_index
+    */
+    int AddGlyph(lua_State* L, Player* player)
+    {
+        uint32 glyph_id = Eluna::CHECKVAL<uint32>(L, 2);
+        uint32 slot_index = Eluna::CHECKVAL<uint32>(L, 3);
+
+        player->SetGlyph(slot_index, glyph_id, !player->GetSession()->PlayerLoading());
+        #if (!defined(TBC) && !defined(CLASSIC))
+            player->SendTalentsInfoData(false); //Also handles GlyphData
+        #endif
+
+        return 0;
+    }
+
 #if !defined(CLASSIC)
     /**
      * Remove cooldowns on spells that have less than 10 minutes of cooldown from the [Player], similarly to when you enter an arena.

--- a/src/LuaEngine/PlayerMethods.h
+++ b/src/LuaEngine/PlayerMethods.h
@@ -3842,8 +3842,8 @@ namespace LuaPlayer
     */
     int SetGlyph(lua_State* L, Player* player)
     {
-        uint32 glyph_id = Eluna::CHECKVAL<uint32>(L, 2);
-        uint32 slot_index = Eluna::CHECKVAL<uint32>(L, 3);
+        uint32 glyphId = Eluna::CHECKVAL<uint32>(L, 2);
+        uint32 slotIndex = Eluna::CHECKVAL<uint32>(L, 3);
 
         player->SetGlyph(slot_index, glyph_id, !player->GetSession()->PlayerLoading());
         #if (!defined(TBC) && !defined(CLASSIC))

--- a/src/LuaEngine/PlayerMethods.h
+++ b/src/LuaEngine/PlayerMethods.h
@@ -3840,7 +3840,7 @@ namespace LuaPlayer
     * @param uint32 glyph_id
     * @param uint32 slot_index
     */
-    int AddGlyph(lua_State* L, Player* player)
+    int SetGlyph(lua_State* L, Player* player)
     {
         uint32 glyph_id = Eluna::CHECKVAL<uint32>(L, 2);
         uint32 slot_index = Eluna::CHECKVAL<uint32>(L, 3);


### PR DESCRIPTION
Adds a Method to the Lua Player Object which allows to set Glyphs for the current TalentGroup/Spec

Compiles: yes
Tested: yes

Test Instructions/example Usage:

1. Create/Use a Paladin (works with every class, but the Glyphs I use in this example are for Paladin)
2. add the following lua example to your lua_scripts folder: 
```
local function OnPlayerCommand(event, player, command)
  if (command == "add_glyph") then
        print("reached_command: add glyph")
        player:SetGlyph(190,0)
        player:SetGlyph(702,3)
        return false
    end
end

RegisterPlayerEvent(42, OnPlayerCommand)
```

3. go ingame, write command .add_glyphs - go to TalentUI, section Glyphs: 2 Glyphs have been set into slot 0 and 3
4. (optional) you can log out and login again if you wan to check if they are persisted in the database.
