### PR TITLE
fix(core/func): GetSpeedRate + SetSpeedRate + ifdefs

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ Eluna API for AC:
 - Added `Player:CanCompleteRepeatableQuest(questId)`: https://github.com/azerothcore/mod-eluna/pull/141
 - Added `Player:CanRewardQuest(questId)`: https://github.com/azerothcore/mod-eluna/pull/141
 - Added `Player:SetGlyph(glyphId, slotIndex)`: https://github.com/azerothcore/mod-eluna/pull/152
+- Added `Unit:SetSpeed(UnitMoveType, speed, forced)`: https://github.com/azerothcore/mod-eluna/pull/155
 
 ### Group
 - Added `Group:GetGroupType()`: https://github.com/azerothcore/mod-eluna/pull/82

--- a/README.md
+++ b/README.md
@@ -101,7 +101,6 @@ Eluna API for AC:
 - Added `Player:CanCompleteRepeatableQuest(questId)`: https://github.com/azerothcore/mod-eluna/pull/141
 - Added `Player:CanRewardQuest(questId)`: https://github.com/azerothcore/mod-eluna/pull/141
 - Added `Player:SetGlyph(glyphId, slotIndex)`: https://github.com/azerothcore/mod-eluna/pull/152
-- Added `Unit:SetSpeed(UnitMoveType, speed, forced)`: https://github.com/azerothcore/mod-eluna/pull/155
 
 ### Group
 - Added `Group:GetGroupType()`: https://github.com/azerothcore/mod-eluna/pull/82
@@ -115,6 +114,8 @@ Eluna API for AC:
 - Added `Unit:GetUnitFlagsTwo()`: https://github.com/azerothcore/mod-eluna/pull/137
 - Added `Unit:SetUnitFlags(flags)`: https://github.com/azerothcore/mod-eluna/pull/137
 - Added `Unit:SetUnitFlagsTwo(flags)`: https://github.com/azerothcore/mod-eluna/pull/137
+- Added `Unit:SetSpeedRate(UnitMoveType, speed)`: https://github.com/azerothcore/mod-eluna/pull/155
+- Added `Unit:SetSpeedRate()`: https://github.com/azerothcore/mod-eluna/pull/155
 
 ### GameObject
 - Added `GameObject:AddLoot()` to add loot at runtime to an **empty** container: https://github.com/azerothcore/mod-eluna/pull/52

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ Eluna API for AC:
 - Added `Unit:GetUnitFlagsTwo()`: https://github.com/azerothcore/mod-eluna/pull/137
 - Added `Unit:SetUnitFlags(flags)`: https://github.com/azerothcore/mod-eluna/pull/137
 - Added `Unit:SetUnitFlagsTwo(flags)`: https://github.com/azerothcore/mod-eluna/pull/137
-- Added `Unit:SetSpeedRate(UnitMoveType, speed)`: https://github.com/azerothcore/mod-eluna/pull/155
+- Added `Unit:SetSpeedRate(unitMoveType, speed)`: https://github.com/azerothcore/mod-eluna/pull/155
 - Added `Unit:SetSpeedRate()`: https://github.com/azerothcore/mod-eluna/pull/155
 
 ### GameObject

--- a/src/LuaEngine/LuaFunctions.cpp
+++ b/src/LuaEngine/LuaFunctions.cpp
@@ -305,6 +305,7 @@ ElunaRegister<Unit> UnitMethods[] =
     { "GetStandState", &LuaUnit::GetStandState },
     { "GetVictim", &LuaUnit::GetVictim },
     { "GetSpeed", &LuaUnit::GetSpeed },
+    { "GetSpeedRate", &LuaUnit::GetSpeedRate },
     { "GetStat", &LuaUnit::GetStat },
     { "GetBaseSpellPower", &LuaUnit::GetBaseSpellPower },
 #if (!defined(TBC) && !defined(CLASSIC))
@@ -327,6 +328,7 @@ ElunaRegister<Unit> UnitMethods[] =
     { "SetFacing", &LuaUnit::SetFacing },
     { "SetFacingToObject", &LuaUnit::SetFacingToObject },
     { "SetSpeed", &LuaUnit::SetSpeed },
+    { "SetSpeedRate", &LuaUnit::SetSpeedRate },
     // {"SetStunned", &LuaUnit::SetStunned},                           // :SetStunned([enable]) - UNDOCUMENTED - Stuns or removes stun
     {"SetRooted", &LuaUnit::SetRooted},
     {"SetConfused", &LuaUnit::SetConfused},

--- a/src/LuaEngine/UnitMethods.h
+++ b/src/LuaEngine/UnitMethods.h
@@ -68,18 +68,8 @@ namespace LuaUnit
      */
     int IsRooted(lua_State* L, Unit* unit)
     {
-#ifdef AZEROTHCORE
         Eluna::Push(L, unit->isInRoots() || unit->HasUnitMovementFlag(MOVEMENTFLAG_ROOT));
-#endif
-#ifdef TRINITY
-        Eluna::Push(L, unit->IsRooted() || unit->HasUnitMovementFlag(MOVEMENTFLAG_ROOT));
-#endif
-#ifdef CMANGOS
-        Eluna::Push(L, unit->isInRoots() || unit->IsRooted());
-#endif
-#ifdef MANGOS
-        Eluna::Push(L, unit->IsInRoots() || unit->IsRooted());
-#endif
+
         return 1;
     }
 
@@ -105,11 +95,8 @@ namespace LuaUnit
     {
         Creature* creature = Eluna::CHECKOBJ<Creature>(L, 2);
 
-#if defined TRINITY || AZEROTHCORE
         Eluna::Push(L, unit->isInAccessiblePlaceFor(creature));
-#else
-        Eluna::Push(L, unit->isInAccessablePlaceFor(creature));
-#endif
+
         return 1;
     }
 
@@ -120,11 +107,8 @@ namespace LuaUnit
      */
     int IsAuctioneer(lua_State* L, Unit* unit)
     {
-#if defined TRINITY || AZEROTHCORE
         Eluna::Push(L, unit->IsAuctioner());
-#else
-        Eluna::Push(L, unit->isAuctioner());
-#endif
+
         return 1;
     }
 
@@ -135,11 +119,7 @@ namespace LuaUnit
      */
     int IsGuildMaster(lua_State* L, Unit* unit)
     {
-#ifdef CMANGOS
-        Eluna::Push(L, unit->isGuildMaster());
-#else
         Eluna::Push(L, unit->IsGuildMaster());
-#endif
         return 1;
     }
 
@@ -150,11 +130,7 @@ namespace LuaUnit
      */
     int IsInnkeeper(lua_State* L, Unit* unit)
     {
-#ifdef CMANGOS
-        Eluna::Push(L, unit->isInnkeeper());
-#else
         Eluna::Push(L, unit->IsInnkeeper());
-#endif
         return 1;
     }
 
@@ -165,11 +141,7 @@ namespace LuaUnit
      */
     int IsTrainer(lua_State* L, Unit* unit)
     {
-#ifdef CMANGOS
-        Eluna::Push(L, unit->isTrainer());
-#else
         Eluna::Push(L, unit->IsTrainer());
-#endif
         return 1;
     }
 
@@ -180,11 +152,7 @@ namespace LuaUnit
      */
     int IsGossip(lua_State* L, Unit* unit)
     {
-#ifdef CMANGOS
-        Eluna::Push(L, unit->isGossip());
-#else
         Eluna::Push(L, unit->IsGossip());
-#endif
         return 1;
     }
 
@@ -195,11 +163,7 @@ namespace LuaUnit
      */
     int IsTaxi(lua_State* L, Unit* unit)
     {
-#ifdef CMANGOS
-        Eluna::Push(L, unit->isTaxi());
-#else
         Eluna::Push(L, unit->IsTaxi());
-#endif
         return 1;
     }
 
@@ -210,11 +174,7 @@ namespace LuaUnit
      */
     int IsSpiritHealer(lua_State* L, Unit* unit)
     {
-#ifdef CMANGOS
-        Eluna::Push(L, unit->isSpiritHealer());
-#else
         Eluna::Push(L, unit->IsSpiritHealer());
-#endif
         return 1;
     }
 
@@ -225,11 +185,7 @@ namespace LuaUnit
      */
     int IsSpiritGuide(lua_State* L, Unit* unit)
     {
-#ifdef CMANGOS
-        Eluna::Push(L, unit->isSpiritGuide());
-#else
         Eluna::Push(L, unit->IsSpiritGuide());
-#endif
         return 1;
     }
 
@@ -240,11 +196,7 @@ namespace LuaUnit
      */
     int IsTabardDesigner(lua_State* L, Unit* unit)
     {
-#ifdef CMANGOS
-        Eluna::Push(L, unit->isTabardDesigner());
-#else
         Eluna::Push(L, unit->IsTabardDesigner());
-#endif
         return 1;
     }
 
@@ -255,11 +207,7 @@ namespace LuaUnit
      */
     int IsServiceProvider(lua_State* L, Unit* unit)
     {
-#ifdef CMANGOS
-        Eluna::Push(L, unit->isServiceProvider());
-#else
         Eluna::Push(L, unit->IsServiceProvider());
-#endif
         return 1;
     }
 
@@ -270,11 +218,7 @@ namespace LuaUnit
      */
     int IsSpiritService(lua_State* L, Unit* unit)
     {
-#ifdef CMANGOS
-        Eluna::Push(L, unit->isSpiritService());
-#else
         Eluna::Push(L, unit->IsSpiritService());
-#endif
         return 1;
     }
 
@@ -285,11 +229,7 @@ namespace LuaUnit
      */
     int IsAlive(lua_State* L, Unit* unit)
     {
-#ifdef CMANGOS
-        Eluna::Push(L, unit->isAlive());
-#else
         Eluna::Push(L, unit->IsAlive());
-#endif
         return 1;
     }
 
@@ -300,11 +240,7 @@ namespace LuaUnit
      */
     int IsDead(lua_State* L, Unit* unit)
     {
-#ifdef MANGOS
-        Eluna::Push(L, unit->IsDead());
-#else
         Eluna::Push(L, unit->isDead());
-#endif
         return 1;
     }
 
@@ -315,11 +251,7 @@ namespace LuaUnit
      */
     int IsDying(lua_State* L, Unit* unit)
     {
-#ifdef MANGOS
-        Eluna::Push(L, unit->IsDying());
-#else
         Eluna::Push(L, unit->isDying());
-#endif
         return 1;
     }
 
@@ -330,11 +262,7 @@ namespace LuaUnit
      */
     int IsBanker(lua_State* L, Unit* unit)
     {
-#ifdef CMANGOS
-        Eluna::Push(L, unit->isBanker());
-#else
         Eluna::Push(L, unit->IsBanker());
-#endif
         return 1;
     }
 
@@ -345,11 +273,7 @@ namespace LuaUnit
      */
     int IsVendor(lua_State* L, Unit* unit)
     {
-#ifdef CMANGOS
-        Eluna::Push(L, unit->isVendor());
-#else
         Eluna::Push(L, unit->IsVendor());
-#endif
         return 1;
     }
 
@@ -360,11 +284,7 @@ namespace LuaUnit
      */
     int IsBattleMaster(lua_State* L, Unit* unit)
     {
-#ifdef CMANGOS
-        Eluna::Push(L, unit->isBattleMaster());
-#else
         Eluna::Push(L, unit->IsBattleMaster());
-#endif
         return 1;
     }
 
@@ -375,11 +295,7 @@ namespace LuaUnit
      */
     int IsCharmed(lua_State* L, Unit* unit)
     {
-#ifdef CMANGOS
-        Eluna::Push(L, unit->isCharmed());
-#else
         Eluna::Push(L, unit->IsCharmed());
-#endif
         return 1;
     }
 
@@ -390,11 +306,7 @@ namespace LuaUnit
      */
     int IsArmorer(lua_State* L, Unit* unit)
     {
-#ifdef CMANGOS
-        Eluna::Push(L, unit->isArmorer());
-#else
         Eluna::Push(L, unit->IsArmorer());
-#endif
         return 1;
     }
 
@@ -428,11 +340,7 @@ namespace LuaUnit
      */
     int IsOnVehicle(lua_State* L, Unit* unit)
     {
-#if defined TRINITY || AZEROTHCORE
         Eluna::Push(L, unit->GetVehicle());
-#else
-        Eluna::Push(L, unit->IsBoarded());
-#endif
         return 1;
     }
 #endif
@@ -444,11 +352,7 @@ namespace LuaUnit
      */
     int IsInCombat(lua_State* L, Unit* unit)
     {
-#ifdef CMANGOS
-        Eluna::Push(L, unit->isInCombat());
-#else
         Eluna::Push(L, unit->IsInCombat());
-#endif
         return 1;
     }
 
@@ -492,11 +396,7 @@ namespace LuaUnit
      */
     int IsQuestGiver(lua_State* L, Unit* unit)
     {
-#ifdef CMANGOS
-        Eluna::Push(L, unit->isQuestGiver());
-#else
         Eluna::Push(L, unit->IsQuestGiver());
-#endif
         return 1;
     }
 
@@ -545,11 +445,7 @@ namespace LuaUnit
      */
     int IsCasting(lua_State* L, Unit* unit)
     {
-#if defined TRINITY || AZEROTHCORE
         Eluna::Push(L, unit->HasUnitState(UNIT_STATE_CASTING));
-#else
-        Eluna::Push(L, unit->IsNonMeleeSpellCasted(false));
-#endif
         return 1;
     }
 
@@ -562,11 +458,7 @@ namespace LuaUnit
     int HasUnitState(lua_State* L, Unit* unit)
     {
         uint32 state = Eluna::CHECKVAL<uint32>(L, 2);
-#if defined TRINITY || AZEROTHCORE
         Eluna::Push(L, unit->HasUnitState(state));
-#else
-        Eluna::Push(L, unit->hasUnitState(state));
-#endif
         return 1;
     }
 
@@ -606,11 +498,7 @@ namespace LuaUnit
      */
     int GetOwnerGUID(lua_State* L, Unit* unit)
     {
-#if defined TRINITY || AZEROTHCORE
         Eluna::Push(L, unit->GetOwnerGUID());
-#else
-        Eluna::Push(L, unit->GetOwnerGuid());
-#endif
         return 1;
     }
 
@@ -632,11 +520,7 @@ namespace LuaUnit
      */
     int GetCreatorGUID(lua_State* L, Unit* unit)
     {
-#if defined TRINITY || AZEROTHCORE
         Eluna::Push(L, unit->GetCreatorGUID());
-#else
-        Eluna::Push(L, unit->GetCreatorGuid());
-#endif
         return 1;
     }
 
@@ -647,11 +531,7 @@ namespace LuaUnit
      */
     int GetCharmerGUID(lua_State* L, Unit* unit)
     {
-#if defined TRINITY || AZEROTHCORE
         Eluna::Push(L, unit->GetCharmerGUID());
-#else
-        Eluna::Push(L, unit->GetCharmerGuid());
-#endif
         return 1;
     }
 
@@ -662,13 +542,7 @@ namespace LuaUnit
      */
     int GetCharmGUID(lua_State* L, Unit* unit)
     {
-#if defined AZEROTHCORE
         Eluna::Push(L, unit->GetCharmGUID());
-#elif defined TRINITY
-        Eluna::Push(L, unit->GetCharmedGUID());
-#else
-        Eluna::Push(L, unit->GetCharmGuid());
-#endif
         return 1;
     }
 
@@ -679,11 +553,7 @@ namespace LuaUnit
      */
     int GetPetGUID(lua_State* L, Unit* unit)
     {
-#if defined TRINITY || AZEROTHCORE
         Eluna::Push(L, unit->GetPetGUID());
-#else
-        Eluna::Push(L, unit->GetPetGuid());
-#endif
         return 1;
     }
 
@@ -694,11 +564,7 @@ namespace LuaUnit
      */
     int GetControllerGUID(lua_State* L, Unit* unit)
     {
-#if defined TRINITY || AZEROTHCORE
         Eluna::Push(L, unit->GetCharmerOrOwnerGUID());
-#else
-        Eluna::Push(L, unit->GetCharmerOrOwnerGuid());
-#endif
         return 1;
     }
 
@@ -709,11 +575,7 @@ namespace LuaUnit
      */
     int GetControllerGUIDS(lua_State* L, Unit* unit)
     {
-#if defined TRINITY || AZEROTHCORE
         Eluna::Push(L, unit->GetCharmerOrOwnerOrOwnGUID());
-#else
-        Eluna::Push(L, unit->GetCharmerOrOwnerOrOwnGuid());
-#endif
         return 1;
     }
 
@@ -758,11 +620,7 @@ namespace LuaUnit
      */
     int GetVictim(lua_State* L, Unit* unit)
     {
-#if defined TRINITY || AZEROTHCORE
         Eluna::Push(L, unit->GetVictim());
-#else
-        Eluna::Push(L, unit->getVictim());
-#endif
         return 1;
     }
 
@@ -799,11 +657,7 @@ namespace LuaUnit
      */
     int GetStandState(lua_State* L, Unit* unit)
     {
-#ifdef TRINITY
-        Eluna::Push(L, unit->GetStandState());
-#else
         Eluna::Push(L, unit->getStandState());
-#endif
         return 1;
     }
 
@@ -853,16 +707,8 @@ namespace LuaUnit
 
     Powers PowerSelectorHelper(lua_State* L, Unit* unit, int powerType = -1)
     {
-#ifdef TRINITY
-        if (powerType == -1)
-            return unit->GetPowerType();
-#elif AZEROTHCORE
         if (powerType == -1)
             return unit->getPowerType();
-#else
-        if (powerType == -1)
-            return unit->GetPowerType();
-#endif
 
         if (powerType < 0 || powerType >= int(MAX_POWERS))
             luaL_argerror(L, 2, "valid Powers expected");
@@ -953,11 +799,8 @@ namespace LuaUnit
         int type = Eluna::CHECKVAL<int>(L, 2, -1);
         Powers power = PowerSelectorHelper(L, unit, type);
 
-#if (!defined(TRINITY) && defined(WOTLK))
         float percent = ((float)unit->GetPower(power) / (float)unit->GetMaxPower(power)) * 100.0f;
-#else
-        float percent = ((float)unit->GetPower(power) / (float)unit->GetMaxPower(power)) * 100.0f;
-#endif
+
         Eluna::Push(L, percent);
         return 1;
     }
@@ -983,13 +826,7 @@ namespace LuaUnit
      */
     int GetPowerType(lua_State* L, Unit* unit)
     {
-#ifdef TRINITY
-        Eluna::Push(L, unit->GetPowerType());
-#elif AZEROTHCORE
         Eluna::Push(L, unit->getPowerType());
-#else
-        Eluna::Push(L, unit->GetPowerType());
-#endif
         return 1;
     }
 
@@ -1011,11 +848,7 @@ namespace LuaUnit
      */
     int GetHealthPct(lua_State* L, Unit* unit)
     {
-#if defined TRINITY || AZEROTHCORE
         Eluna::Push(L, unit->GetHealthPct());
-#else
-        Eluna::Push(L, unit->GetHealthPercent());
-#endif
         return 1;
     }
 
@@ -1026,11 +859,7 @@ namespace LuaUnit
      */
     int GetGender(lua_State* L, Unit* unit)
     {
-#ifdef TRINITY
-        Eluna::Push(L, unit->GetGender());
-#else
         Eluna::Push(L, unit->getGender());
-#endif
         return 1;
     }
 
@@ -1041,11 +870,7 @@ namespace LuaUnit
      */
     int GetRace(lua_State* L, Unit* unit)
     {
-#ifdef TRINITY
-        Eluna::Push(L, unit->GetRace());
-#else
         Eluna::Push(L, unit->getRace());
-#endif
         return 1;
     }
 
@@ -1056,11 +881,7 @@ namespace LuaUnit
      */
     int GetClass(lua_State* L, Unit* unit)
     {
-#ifdef TRINITY
-        Eluna::Push(L, unit->GetClass());
-#else
         Eluna::Push(L, unit->getClass());
-#endif
         return 1;
     }
 
@@ -1071,11 +892,7 @@ namespace LuaUnit
     */
     int GetRaceMask(lua_State* L, Unit* unit)
     {
-#ifdef TRINITY
-        Eluna::Push(L, unit->GetRaceMask());
-#else
         Eluna::Push(L, unit->getRaceMask());
-#endif
         return 1;
     }
 
@@ -1086,11 +903,7 @@ namespace LuaUnit
     */
     int GetClassMask(lua_State* L, Unit* unit)
     {
-#ifdef TRINITY
-        Eluna::Push(L, unit->GetClassMask());
-#else
         Eluna::Push(L, unit->getClassMask());
-#endif
         return 1;
     }
 
@@ -1151,19 +964,11 @@ namespace LuaUnit
         if (locale >= TOTAL_LOCALES)
             return luaL_argerror(L, 2, "valid LocaleConstant expected");
 
-#ifdef TRINITY
-        const ChrClassesEntry* entry = sChrClassesStore.LookupEntry(unit->GetClass());
-#else
         const ChrClassesEntry* entry = sChrClassesStore.LookupEntry(unit->getClass());
-#endif
         if (!entry)
             return 1;
 
-#ifdef TRINITY
-        Eluna::Push(L, entry->Name[locale]);
-#else
         Eluna::Push(L, entry->name[locale]);
-#endif
         return 1;
     }
 
@@ -1194,19 +999,11 @@ namespace LuaUnit
         if (locale >= TOTAL_LOCALES)
             return luaL_argerror(L, 2, "valid LocaleConstant expected");
 
-#ifdef TRINITY
-        const ChrRacesEntry* entry = sChrRacesStore.LookupEntry(unit->GetRace());
-#else
         const ChrRacesEntry* entry = sChrRacesStore.LookupEntry(unit->getRace());
-#endif
         if (!entry)
             return 1;
 
-#ifdef TRINITY
-        Eluna::Push(L, entry->Name[locale]);
-#else
         Eluna::Push(L, entry->name[locale]);
-#endif
         return 1;
     }
 
@@ -1217,11 +1014,7 @@ namespace LuaUnit
      */
     int GetFaction(lua_State* L, Unit* unit)
     {
-#if defined TRINITY || AZEROTHCORE
         Eluna::Push(L, unit->GetFaction());
-#else
-        Eluna::Push(L, unit->getFaction());
-#endif
         return 1;
     }
 
@@ -1234,11 +1027,7 @@ namespace LuaUnit
     int GetAura(lua_State* L, Unit* unit)
     {
         uint32 spellID = Eluna::CHECKVAL<uint32>(L, 2);
-#if defined TRINITY || AZEROTHCORE
         Eluna::Push(L, unit->GetAura(spellID));
-#else
-        Eluna::Push(L, unit->GetAura(spellID, EFFECT_INDEX_0));
-#endif
         return 1;
     }
 
@@ -1253,19 +1042,11 @@ namespace LuaUnit
         float range = Eluna::CHECKVAL<float>(L, 2, SIZE_OF_GRIDS);
 
         std::list<Unit*> list;
-#ifdef TRINITY
-        Trinity::AnyFriendlyUnitInObjectRangeCheck checker(unit, unit, range);
-        Trinity::UnitListSearcher<Trinity::AnyFriendlyUnitInObjectRangeCheck> searcher(unit, list, checker);
-        Cell::VisitAllObjects(unit, searcher, range);
-#elif AZEROTHCORE
+
         Acore::AnyFriendlyUnitInObjectRangeCheck checker(unit, unit, range);
         Acore::UnitListSearcher<Acore::AnyFriendlyUnitInObjectRangeCheck> searcher(unit, list, checker);
         Cell::VisitAllObjects(unit, searcher, range);
-#else
-        MaNGOS::AnyFriendlyUnitInObjectRangeCheck checker(unit, range);
-        MaNGOS::UnitListSearcher<MaNGOS::AnyFriendlyUnitInObjectRangeCheck> searcher(list, checker);
-        Cell::VisitGridObjects(unit, searcher, range);
-#endif
+
         ElunaUtil::ObjectGUIDCheck guidCheck(unit->GET_GUID());
         list.remove_if(guidCheck);
 
@@ -1294,19 +1075,9 @@ namespace LuaUnit
         float range = Eluna::CHECKVAL<float>(L, 2, SIZE_OF_GRIDS);
 
         std::list<Unit*> list;
-#ifdef TRINITY
-        Trinity::AnyUnfriendlyUnitInObjectRangeCheck checker(unit, unit, range);
-        Trinity::UnitListSearcher<Trinity::AnyUnfriendlyUnitInObjectRangeCheck> searcher(unit, list, checker);
-        Cell::VisitAllObjects(unit, searcher, range);
-#elif AZEROTHCORE
         Acore::AnyUnfriendlyUnitInObjectRangeCheck checker(unit, unit, range);
         Acore::UnitListSearcher<Acore::AnyUnfriendlyUnitInObjectRangeCheck> searcher(unit, list, checker);
         Cell::VisitAllObjects(unit, searcher, range);
-#else
-        MaNGOS::AnyUnfriendlyUnitInObjectRangeCheck checker(unit, range);
-        MaNGOS::UnitListSearcher<MaNGOS::AnyUnfriendlyUnitInObjectRangeCheck> searcher(list, checker);
-        Cell::VisitGridObjects(unit, searcher, range);
-#endif
         ElunaUtil::ObjectGUIDCheck guidCheck(unit->GET_GUID());
         list.remove_if(guidCheck);
 
@@ -1332,11 +1103,7 @@ namespace LuaUnit
      */
     int GetVehicleKit(lua_State* L, Unit* unit)
     {
-#if defined TRINITY || AZEROTHCORE
         Eluna::Push(L, unit->GetVehicleKit());
-#else
-        Eluna::Push(L, unit->GetVehicleInfo());
-#endif
         return 1;
     }
 
@@ -1355,11 +1122,7 @@ namespace LuaUnit
      */
     int GetCritterGUID(lua_State* L, Unit* unit)
     {
-#if defined TRINITY || AZEROTHCORE
         Eluna::Push(L, unit->GetCritterGUID());
-#else
-        Eluna::Push(L, unit->GetCritterGuid());
-#endif
         return 1;
     }
 #endif
@@ -1391,11 +1154,40 @@ namespace LuaUnit
         if (type >= MAX_MOVE_TYPE)
             return luaL_argerror(L, 2, "valid UnitMoveType expected");
 
-#ifndef TRINITY
-        Eluna::Push(L, unit->GetSpeedRate((UnitMoveType)type));
-#else
         Eluna::Push(L, unit->GetSpeed((UnitMoveType)type));
-#endif
+
+        return 1;
+    }
+
+    /**
+    * Returns the [Unit]'s speed rate of given [UnitMoveType].
+    *
+    * <pre>
+    * enum UnitMoveType
+    * {
+    *     MOVE_WALK           = 0,
+    *     MOVE_RUN            = 1,
+    *     MOVE_RUN_BACK       = 2,
+    *     MOVE_SWIM           = 3,
+    *     MOVE_SWIM_BACK      = 4,
+    *     MOVE_TURN_RATE      = 5,
+    *     MOVE_FLIGHT         = 6,
+    *     MOVE_FLIGHT_BACK    = 7,
+    *     MOVE_PITCH_RATE     = 8
+    * };
+    * </pre>
+    *
+    * @param [UnitMoveType] type
+    * @return float speed
+    */
+    int GetSpeedRate(lua_State* L, Unit* unit)
+    {
+        uint32 type = Eluna::CHECKVAL<uint32>(L, 2);
+        if (type >= MAX_MOVE_TYPE)
+            return luaL_argerror(L, 2, "valid UnitMoveType expected");
+
+        Eluna::Push(L, unit->GetSpeedRate((UnitMoveType)type));
+
         return 1;
     }
 
@@ -1474,11 +1266,7 @@ namespace LuaUnit
     {
         ObjectGuid guid = Eluna::CHECKVAL<ObjectGuid>(L, 2);
 
-#if defined TRINITY || AZEROTHCORE
         unit->SetOwnerGUID(guid);
-#else
-        unit->SetOwnerGuid(guid);
-#endif
         return 0;
     }
 
@@ -1531,7 +1319,7 @@ namespace LuaUnit
     }
 
     /**
-     * Sets the [Unit]'s speed of given [UnitMoveType] to given rate.
+     * Sets the [Unit]'s speed of given [UnitMoveType] to given speed.
      * If forced, packets sent to clients forcing the visual change.
      *
      * <pre>
@@ -1561,11 +1349,46 @@ namespace LuaUnit
         (void)forced; // ensure that the variable is referenced in order to pass compiler checks
         if (type >= MAX_MOVE_TYPE)
             return luaL_argerror(L, 2, "valid UnitMoveType expected");
-#if defined TRINITY || AZEROTHCORE
+
+        unit->SetSpeed((UnitMoveType)type, rate);
+
+        return 0;
+    }
+
+    /**
+     * Sets the [Unit]'s speed rate of given [UnitMoveType] to given rate.
+     * If forced, packets sent to clients forcing the visual change.
+     *
+     * <pre>
+     * enum UnitMoveType
+     * {
+     *     MOVE_WALK           = 0,
+     *     MOVE_RUN            = 1,
+     *     MOVE_RUN_BACK       = 2,
+     *     MOVE_SWIM           = 3,
+     *     MOVE_SWIM_BACK      = 4,
+     *     MOVE_TURN_RATE      = 5,
+     *     MOVE_FLIGHT         = 6,
+     *     MOVE_FLIGHT_BACK    = 7,
+     *     MOVE_PITCH_RATE     = 8
+     * };
+     * </pre>
+     *
+     * @param [UnitMoveType] type
+     * @param float rate
+     * @param bool forced = false
+     */
+    int SetSpeedRate(lua_State* L, Unit* unit)
+    {
+        uint32 type = Eluna::CHECKVAL<uint32>(L, 2);
+        float rate = Eluna::CHECKVAL<float>(L, 3);
+        bool forced = Eluna::CHECKVAL<bool>(L, 4, false);
+        (void)forced; // ensure that the variable is referenced in order to pass compiler checks
+        if (type >= MAX_MOVE_TYPE)
+            return luaL_argerror(L, 2, "valid UnitMoveType expected");
+
         unit->SetSpeedRate((UnitMoveType)type, rate);
-#else
-        unit->SetSpeedRate((UnitMoveType)type, rate, forced);
-#endif
+
         return 0;
     }
 
@@ -1577,11 +1400,9 @@ namespace LuaUnit
     int SetFaction(lua_State* L, Unit* unit)
     {
         uint32 factionId = Eluna::CHECKVAL<uint32>(L, 2);
-#if defined TRINITY || AZEROTHCORE
+
         unit->SetFaction(factionId);
-#else
-        unit->setFaction(factionId);
-#endif
+
         return 0;
     }
 
@@ -1748,13 +1569,7 @@ namespace LuaUnit
         if (type >= int(MAX_POWERS))
             return luaL_argerror(L, 2, "valid Powers expected");
 
-#ifdef TRINITY
-        unit->SetPowerType((Powers)type);
-#elif AZEROTHCORE
         unit->setPowerType((Powers)type);
-#else
-        unit->SetPowerType((Powers)type);
-#endif
         return 0;
     }
 
@@ -1814,11 +1629,7 @@ namespace LuaUnit
     int SetCreatorGUID(lua_State* L, Unit* unit)
     {
         ObjectGuid guid = Eluna::CHECKVAL<ObjectGuid>(L, 2);
-#if defined TRINITY || AZEROTHCORE
         unit->SetCreatorGUID(guid);
-#else
-        unit->SetCreatorGuid(guid);
-#endif
         return 0;
     }
 
@@ -1830,11 +1641,7 @@ namespace LuaUnit
     int SetPetGUID(lua_State* L, Unit* unit)
     {
         ObjectGuid guid = Eluna::CHECKVAL<ObjectGuid>(L, 2);
-#if defined TRINITY || AZEROTHCORE
         unit->SetPetGUID(guid);
-#else
-        unit->SetPetGuid(guid);
-#endif
         return 0;
     }
 
@@ -1846,11 +1653,7 @@ namespace LuaUnit
     int SetWaterWalk(lua_State* L, Unit* unit)
     {
         bool enable = Eluna::CHECKVAL<bool>(L, 2, true);
-#if defined TRINITY || AZEROTHCORE
         unit->SetWaterWalking(enable);
-#else
-        unit->SetWaterWalk(enable);
-#endif
         return 0;
     }
 
@@ -1888,20 +1691,6 @@ namespace LuaUnit
     {
         bool apply = Eluna::CHECKVAL<bool>(L, 2, true);
 
-#ifdef TRINITY
-        if (apply)
-        {
-            unit->SetByteFlag(UNIT_FIELD_BYTES_2, 1, UNIT_BYTE2_FLAG_FFA_PVP);
-            for (Unit::ControlList::iterator itr = unit->m_Controlled.begin(); itr != unit->m_Controlled.end(); ++itr)
-                (*itr)->SetByteValue(UNIT_FIELD_BYTES_2, 1, UNIT_BYTE2_FLAG_FFA_PVP);
-        }
-        else
-        {
-            unit->RemoveByteFlag(UNIT_FIELD_BYTES_2, 1, UNIT_BYTE2_FLAG_FFA_PVP);
-            for (Unit::ControlList::iterator itr = unit->m_Controlled.begin(); itr != unit->m_Controlled.end(); ++itr)
-                (*itr)->RemoveByteFlag(UNIT_FIELD_BYTES_2, 1, UNIT_BYTE2_FLAG_FFA_PVP);
-        }
-#elif AZEROTHCORE
         if (apply)
         {
             unit->SetByteFlag(UNIT_FIELD_BYTES_2, 1, UNIT_BYTE2_FLAG_FFA_PVP);
@@ -1914,9 +1703,6 @@ namespace LuaUnit
             for (Unit::ControlSet::iterator itr = unit->m_Controlled.begin(); itr != unit->m_Controlled.end(); ++itr)
                 (*itr)->RemoveByteFlag(UNIT_FIELD_BYTES_2, 1, UNIT_BYTE2_FLAG_FFA_PVP);
         }
-#else
-        unit->SetFFAPvP(apply);
-#endif
         return 0;
     }
 
@@ -1944,11 +1730,7 @@ namespace LuaUnit
     int SetCritterGUID(lua_State* L, Unit* unit)
     {
         ObjectGuid guid = Eluna::CHECKVAL<ObjectGuid>(L, 2);
-#if defined TRINITY || AZEROTHCORE
         unit->SetCritterGUID(guid);
-#else
-        unit->SetCritterGuid(guid);
-#endif
         return 0;
     }
 #endif
@@ -1968,11 +1750,7 @@ namespace LuaUnit
     int SetRooted(lua_State* L, Unit* unit)
     {
         bool apply = Eluna::CHECKVAL<bool>(L, 2, true);
-#if defined TRINITY || AZEROTHCORE
         unit->SetControlled(apply, UNIT_STATE_ROOT);
-#else
-        unit->SetRoot(apply);
-#endif
         return 0;
     }
 
@@ -1984,11 +1762,7 @@ namespace LuaUnit
     int SetConfused(lua_State* L, Unit* unit)
     {
         bool apply = Eluna::CHECKVAL<bool>(L, 2, true);
-#if defined TRINITY || AZEROTHCORE
         unit->SetControlled(apply, UNIT_STATE_CONFUSED);
-#else
-        unit->SetConfused(apply);
-#endif
         return 0;
     }
 
@@ -2000,11 +1774,7 @@ namespace LuaUnit
     int SetFeared(lua_State* L, Unit* unit)
     {
         bool apply = Eluna::CHECKVAL<bool>(L, 2, true);
-#if defined TRINITY || AZEROTHCORE
         unit->SetControlled(apply, UNIT_STATE_FLEEING);
-#else
-        unit->SetFeared(apply);
-#endif
         return 0;
     }
 
@@ -2027,13 +1797,7 @@ namespace LuaUnit
      */
     int ClearThreatList(lua_State* /*L*/, Unit* unit)
     {
-#ifdef TRINITY
-        unit->GetThreatManager().ClearAllThreat();
-#elif AZEROTHCORE
         unit->GetThreatMgr().ClearAllThreat();
-#else
-        unit->GetThreatManager().clearReferences();
-#endif
         return 0;
     }
 
@@ -2096,13 +1860,8 @@ namespace LuaUnit
     {
         if (unit->IsMounted())
         {
-#if defined TRINITY || AZEROTHCORE
             unit->Dismount();
             unit->RemoveAurasByType(SPELL_AURA_MOUNTED);
-#else
-            unit->Unmount();
-            unit->RemoveSpellsCausingAura(SPELL_AURA_MOUNTED);
-#endif
         }
 
         return 0;
@@ -2115,12 +1874,7 @@ namespace LuaUnit
      */
     int PerformEmote(lua_State* L, Unit* unit)
     {
-#ifdef TRINITY
-        Emote emote = static_cast<Emote>(Eluna::CHECKVAL<uint32>(L, 2));
-        unit->HandleEmoteCommand(emote);
-#else
         unit->HandleEmoteCommand(Eluna::CHECKVAL<uint32>(L, 2));
-#endif
         return 0;
     }
 
@@ -2180,16 +1934,8 @@ namespace LuaUnit
             return luaL_argerror(L, 3, "valid Language expected");
 
         WorldPacket data;
-#if defined TRINITY || AZEROTHCORE
         ChatHandler::BuildChatPacket(data, ChatMsg(type), Language(lang), unit, target, msg);
-#else
-        ChatHandler::BuildChatPacket(data, ChatMsg(type), msg.c_str(), Language(lang), 0, unit->GET_GUID(), unit->GetName(), target->GET_GUID(), target->GetName());
-#endif
-#ifdef CMANGOS
-        target->GetSession()->SendPacket(data);
-#else
         target->GetSession()->SendPacket(&data);
-#endif
         return 0;
     }
 
@@ -2216,13 +1962,8 @@ namespace LuaUnit
      */
     int MoveExpire(lua_State* L, Unit* unit)
     {
-#ifdef TRINITY
-        (void) L; // ensure that the variable is referenced in order to pass compiler checks
-        unit->GetMotionMaster()->Clear();
-#else
         bool reset = Eluna::CHECKVAL<bool>(L, 2, true);
         unit->GetMotionMaster()->MovementExpired(reset);
-#endif
         return 0;
     }
 
@@ -2233,13 +1974,8 @@ namespace LuaUnit
      */
     int MoveClear(lua_State* L, Unit* unit)
     {
-#ifdef TRINITY
-        (void) L; // ensure that the variable is referenced in order to pass compiler checks
-        unit->GetMotionMaster()->Clear();
-#else
         bool reset = Eluna::CHECKVAL<bool>(L, 2, true);
         unit->GetMotionMaster()->Clear(reset);
-#endif
         return 0;
     }
 
@@ -2262,11 +1998,7 @@ namespace LuaUnit
         float radius = Eluna::CHECKVAL<float>(L, 2);
         float x, y, z;
         unit->GetPosition(x, y, z);
-#if defined TRINITY || AZEROTHCORE
         unit->GetMotionMaster()->MoveRandom(radius);
-#else
-        unit->GetMotionMaster()->MoveRandomAroundPoint(x, y, z, radius);
-#endif
         return 0;
     }
 
@@ -2373,13 +2105,8 @@ namespace LuaUnit
         float zSpeed = Eluna::CHECKVAL<float>(L, 5);
         float maxHeight = Eluna::CHECKVAL<float>(L, 6);
         uint32 id = Eluna::CHECKVAL<uint32>(L, 7, 0);
-
-#if (defined(CMANGOS) || defined(MANGOS)) && defined(WOTLK)
-        unit->GetMotionMaster()->MoveJump(x, y, z, zSpeed, maxHeight, id);
-#else
         Position pos(x, y, z);
         unit->GetMotionMaster()->MoveJump(pos, zSpeed, maxHeight, id);
-#endif
         return 0;
     }
 #endif
@@ -2400,11 +2127,7 @@ namespace LuaUnit
         Player* receiver = Eluna::CHECKOBJ<Player>(L, 4);
         bool bossWhisper = Eluna::CHECKVAL<bool>(L, 5, false);
         if (std::string(msg).length() > 0)
-#if defined(TRINITY) || defined(AZEROTHCORE)
             unit->Whisper(msg, (Language)lang, receiver, bossWhisper);
-#else
-            unit->MonsterWhisper(msg, receiver, bossWhisper);
-#endif
         return 0;
     }
 
@@ -2421,11 +2144,7 @@ namespace LuaUnit
         Unit* receiver = Eluna::CHECKOBJ<Unit>(L, 3, false);
         bool bossEmote = Eluna::CHECKVAL<bool>(L, 4, false);
         if (std::string(msg).length() > 0)
-#if defined(TRINITY) || defined(AZEROTHCORE)
             unit->TextEmote(msg, receiver, bossEmote);
-#else
-            unit->MonsterTextEmote(msg, receiver, bossEmote);
-#endif
         return 0;
     }
 
@@ -2440,11 +2159,7 @@ namespace LuaUnit
         const char* msg = Eluna::CHECKVAL<const char*>(L, 2);
         uint32 language = Eluna::CHECKVAL<uint32>(L, 3);
         if (std::string(msg).length() > 0)
-#if defined(TRINITY) || defined(AZEROTHCORE)
             unit->Say(msg, (Language)language, unit);
-#else
-            unit->MonsterSay(msg, language, unit);
-#endif
         return 0;
     }
 
@@ -2459,11 +2174,7 @@ namespace LuaUnit
         const char* msg = Eluna::CHECKVAL<const char*>(L, 2);
         uint32 language = Eluna::CHECKVAL<uint32>(L, 3);
         if (std::string(msg).length() > 0)
-#if defined(TRINITY) || defined(AZEROTHCORE)
             unit->Yell(msg, (Language)language, unit);
-#else
-            unit->MonsterYell(msg, language, unit);
-#endif
         return 0;
     }
 
@@ -2488,23 +2199,11 @@ namespace LuaUnit
         Unit* target = Eluna::CHECKOBJ<Unit>(L, 2, false);
         uint32 spell = Eluna::CHECKVAL<uint32>(L, 3);
         bool triggered = Eluna::CHECKVAL<bool>(L, 4, false);
-#ifdef CMANGOS
-        SpellEntry const* spellEntry = GetSpellStore()->LookupEntry<SpellEntry>(spell);
-#endif
-#ifdef MANGOS
-        SpellEntry const* spellEntry = sSpellStore.LookupEntry(spell);
-#endif
-#if defined TRINITY || AZEROTHCORE
         SpellInfo const* spellEntry = sSpellMgr->GetSpellInfo(spell);
-#endif
         if (!spellEntry)
             return 0;
 
-#ifdef CMANGOS
-        unit->CastSpell(target, spell, TRIGGERED_OLD_TRIGGERED);
-#else
         unit->CastSpell(target, spell, triggered);
-#endif
         return 0;
     }
 
@@ -2535,24 +2234,7 @@ namespace LuaUnit
         Item* castItem = Eluna::CHECKOBJ<Item>(L, 8, false);
         ObjectGuid originalCaster = Eluna::CHECKVAL<ObjectGuid>(L, 9, ObjectGuid());
 
-#ifdef TRINITY
-        CastSpellExtraArgs args;
-        if (has_bp0)
-            args.AddSpellMod(SPELLVALUE_BASE_POINT0, bp0);
-        if (has_bp1)
-            args.AddSpellMod(SPELLVALUE_BASE_POINT1, bp1);
-        if (has_bp2)
-            args.AddSpellMod(SPELLVALUE_BASE_POINT2, bp2);
-        if (triggered)
-            args.TriggerFlags = TRIGGERED_FULL_MASK;
-        if (castItem)
-            args.SetCastItem(castItem);
-        if (originalCaster)
-            args.SetOriginalCaster(originalCaster);
-        unit->CastSpell(target, spell, args);
-#else
         unit->CastCustomSpell(target, spell, has_bp0 ? &bp0 : NULL, has_bp1 ? &bp1 : NULL, has_bp2 ? &bp2 : NULL, triggered, castItem, NULL, ObjectGuid(originalCaster));
-#endif
         return 0;
     }
 
@@ -2572,21 +2254,7 @@ namespace LuaUnit
         float _z = Eluna::CHECKVAL<float>(L, 4);
         uint32 spell = Eluna::CHECKVAL<uint32>(L, 5);
         bool triggered = Eluna::CHECKVAL<bool>(L, 6, true);
-#ifdef CMANGOS
-        unit->CastSpell(_x, _y, _z, spell, TRIGGERED_OLD_TRIGGERED);
-#endif
-#ifdef MANGOS
         unit->CastSpell(_x, _y, _z, spell, triggered);
-#endif
-#ifdef AZEROTHCORE
-        unit->CastSpell(_x, _y, _z, spell, triggered);
-#endif
-#ifdef TRINITY
-        CastSpellExtraArgs args;
-        if (triggered)
-            args.TriggerFlags = TRIGGERED_FULL_MASK;
-        unit->CastSpell(Position(_x, _y, _z), spell, args);
-#endif
         return 0;
     }
 
@@ -2656,44 +2324,11 @@ namespace LuaUnit
     {
         uint32 spell = Eluna::CHECKVAL<uint32>(L, 2);
         Unit* target = Eluna::CHECKOBJ<Unit>(L, 3);
-#ifdef CMANGOS
-        SpellEntry const* spellEntry = GetSpellStore()->LookupEntry<SpellEntry>(spell);
-#endif
-#ifdef MANGOS
-        SpellEntry const* spellEntry = sSpellStore.LookupEntry(spell);
-#endif
-#ifdef TRINITY
         SpellInfo const* spellEntry = sSpellMgr->GetSpellInfo(spell);
-#endif
-#ifdef AZEROTHCORE
-        SpellInfo const* spellEntry = sSpellMgr->GetSpellInfo(spell);
-#endif
         if (!spellEntry)
             return 1;
 
-#if defined TRINITY || AZEROTHCORE
         Eluna::Push(L, unit->AddAura(spell, target));
-#else
-        if (!IsSpellAppliesAura(spellEntry) && !IsSpellHaveEffect(spellEntry, SPELL_EFFECT_PERSISTENT_AREA_AURA))
-            return 1;
-
-        SpellAuraHolder* holder = CreateSpellAuraHolder(spellEntry, target, unit);
-
-        for (uint32 i = 0; i < MAX_EFFECT_INDEX; ++i)
-        {
-            uint8 eff = spellEntry->Effect[i];
-            if (eff >= TOTAL_SPELL_EFFECTS)
-                continue;
-            if (IsAreaAuraEffect(eff) ||
-                eff == SPELL_EFFECT_APPLY_AURA ||
-                eff == SPELL_EFFECT_PERSISTENT_AREA_AURA)
-            {
-                Aura* aur = CreateAura(spellEntry, SpellEffIndex(i), NULL, holder, target);
-                holder->AddAura(aur, SpellEffIndex(i));
-            }
-        }
-        Eluna::Push(L, target->AddSpellAuraHolder(holder));
-#endif
         return 1;
     }
 
@@ -2740,11 +2375,7 @@ namespace LuaUnit
     {
         uint32 state = Eluna::CHECKVAL<uint32>(L, 2);
 
-#if defined TRINITY || AZEROTHCORE
         unit->AddUnitState(state);
-#else
-        unit->addUnitState(state);
-#endif
         return 0;
     }
 
@@ -2757,11 +2388,7 @@ namespace LuaUnit
     {
         uint32 state = Eluna::CHECKVAL<uint32>(L, 2);
 
-#if defined TRINITY || AZEROTHCORE
         unit->ClearUnitState(state);
-#else
-        unit->clearUnitState(state);
-#endif
         return 0;
     }
 
@@ -2820,71 +2447,16 @@ namespace LuaUnit
         // flat melee damage without resistence/etc reduction
         if (school == MAX_SPELL_SCHOOL)
         {
-#if defined TRINITY || AZEROTHCORE
             Unit::DealDamage(unit, target, damage, NULL, DIRECT_DAMAGE, SPELL_SCHOOL_MASK_NORMAL, NULL, durabilityloss);
             unit->SendAttackStateUpdate(HITINFO_AFFECTS_VICTIM, target, 1, SPELL_SCHOOL_MASK_NORMAL, damage, 0, 0, VICTIMSTATE_HIT, 0);
-#else
-            unit->DealDamage(target, damage, NULL, DIRECT_DAMAGE, SPELL_SCHOOL_MASK_NORMAL, NULL, durabilityloss);
-            unit->SendAttackStateUpdate(HITINFO_NORMALSWING2, target, SPELL_SCHOOL_MASK_NORMAL, damage, 0, 0, VICTIMSTATE_NORMAL, 0);
-#endif
             return 0;
         }
 
         SpellSchoolMask schoolmask = SpellSchoolMask(1 << school);
 
-#if defined TRINITY || AZEROTHCORE
         if (Unit::IsDamageReducedByArmor(schoolmask))
             damage = Unit::CalcArmorReducedDamage(unit, target, damage, NULL, BASE_ATTACK);
-#else
-        if (schoolmask & SPELL_SCHOOL_MASK_NORMAL)
-            damage = unit->CalcArmorReducedDamage(target, damage);
-#endif
 
-#ifdef TRINITY
-        // melee damage by specific school
-        if (!spell)
-        {
-            DamageInfo dmgInfo(unit, target, damage, nullptr, schoolmask, SPELL_DIRECT_DAMAGE, BASE_ATTACK);
-            unit->CalcAbsorbResist(dmgInfo);
-
-            if (!dmgInfo.GetDamage())
-                damage = 0;
-            else
-                damage = dmgInfo.GetDamage();
-
-            uint32 absorb = dmgInfo.GetAbsorb();
-            uint32 resist = dmgInfo.GetResist();
-            unit->DealDamageMods(target, damage, &absorb);
-#ifdef TRINITY
-            Unit::DealDamage(unit, target, damage, NULL, DIRECT_DAMAGE, schoolmask, NULL, false);
-#else
-            unit->DealDamage(target, damage, NULL, DIRECT_DAMAGE, schoolmask, NULL, false);
-#endif
-            unit->SendAttackStateUpdate(HITINFO_AFFECTS_VICTIM, target, 0, schoolmask, damage, absorb, resist, VICTIMSTATE_HIT, 0);
-            return 0;
-        }
-
-        if (!spell)
-            return 0;
-
-        SpellInfo const* spellInfo = sSpellMgr->GetSpellInfo(spell);
-        if (!spellInfo)
-            return 0;
-
-        SpellNonMeleeDamage dmgInfo(unit, target, spell, spellInfo->GetSchoolMask());
-#ifdef TRINITY
-        Unit::DealDamageMods(dmgInfo.target, dmgInfo.damage, &dmgInfo.absorb);
-#else
-        damage = unit->SpellDamageBonusDone(target, spellInfo, damage, SPELL_DIRECT_DAMAGE;
-        damage = target->SpellDamageBonusTaken(unit, spellInfo, damage, SPELL_DIRECT_DAMAGE);
-        unit->CalculateSpellDamageTaken(&dmgInfo, damage, spellInfo);
-        unit->DealDamageMods(dmgInfo.target, dmgInfo.damage, &dmgInfo.absorb);
-#endif
-
-        unit->SendSpellNonMeleeDamageLog(&dmgInfo);
-        unit->DealSpellDamage(&dmgInfo, true);
-        return 0;
-#elif AZEROTHCORE
         if (!spell)
         {
             DamageInfo dmgInfo(unit, target, damage, nullptr, schoolmask, SPELL_DIRECT_DAMAGE);
@@ -2915,29 +2487,6 @@ namespace LuaUnit
         unit->SendSpellNonMeleeDamageLog(&dmgInfo);
         unit->DealSpellDamage(&dmgInfo, true);
         return 0;
-#else
-        // melee damage by specific school
-        if (!spell)
-        {
-            uint32 absorb = 0;
-            uint32 resist = 0;
-            target->CalculateDamageAbsorbAndResist(unit, schoolmask, SPELL_DIRECT_DAMAGE, damage, &absorb, &resist);
-
-            if (damage <= absorb + resist)
-                damage = 0;
-            else
-                damage -= absorb + resist;
-
-            unit->DealDamageMods(target, damage, &absorb);
-            unit->DealDamage(target, damage, NULL, DIRECT_DAMAGE, schoolmask, NULL, false);
-            unit->SendAttackStateUpdate(HITINFO_NORMALSWING2, target, schoolmask, damage, absorb, resist, VICTIMSTATE_NORMAL, 0);
-            return 0;
-        }
-
-        // non-melee damage
-        unit->SpellNonMeleeDamageLog(target, spell, damage);
-        return 0;
-#endif
     }
 
     /**
@@ -2955,21 +2504,11 @@ namespace LuaUnit
         uint32 amount = Eluna::CHECKVAL<uint32>(L, 4);
         bool critical = Eluna::CHECKVAL<bool>(L, 5, false);
 
-#if defined TRINITY || AZEROTHCORE
         if (const SpellInfo* info = sSpellMgr->GetSpellInfo(spell))
         {
             HealInfo healInfo(unit, target, amount, info, info->GetSchoolMask());
             unit->HealBySpell(healInfo, critical);
         }
-#else
-#ifdef CMANGOS
-        SpellEntry const* spellEntry = GetSpellStore()->LookupEntry<SpellEntry>(spell);
-#else
-        SpellEntry const* spellEntry = sSpellStore.LookupEntry(spell);
-#endif
-        if (spellEntry)
-            unit->DealHeal(target, amount, spellEntry, critical);
-#endif
         return 0;
     }
 
@@ -2984,11 +2523,7 @@ namespace LuaUnit
         Unit* target = Eluna::CHECKOBJ<Unit>(L, 2);
         bool durLoss = Eluna::CHECKVAL<bool>(L, 3, true);
 
-#if defined TRINITY || AZEROTHCORE
         Unit::Kill(unit, target, durLoss);
-#else
-        unit->DealDamage(target, target->GetHealth(), NULL, DIRECT_DAMAGE, SPELL_SCHOOL_MASK_NORMAL, NULL, durLoss);
-#endif
         return 0;
     }
 
@@ -3020,28 +2555,12 @@ namespace LuaUnit
         float threat = Eluna::CHECKVAL<float>(L, 3, true);
         uint32 spell = Eluna::CHECKVAL<uint32>(L, 4, 0);
 
-#ifdef TRINITY
-        unit->GetThreatManager().AddThreat(victim, threat, spell ? sSpellMgr->GetSpellInfo(spell) : NULL, true, true);
-#elif AZEROTHCORE
         uint32 schoolMask = Eluna::CHECKVAL<uint32>(L, 5, 0);
         if (schoolMask > SPELL_SCHOOL_MASK_ALL)
         {
             return luaL_argerror(L, 4, "valid SpellSchoolMask expected");
         }
         unit->AddThreat(victim, threat, (SpellSchoolMask)schoolMask, spell ? sSpellMgr->GetSpellInfo(spell) : NULL);
-#else
-#ifdef CMANGOS
-        SpellEntry const* spellEntry = GetSpellStore()->LookupEntry<SpellEntry>(spell);
-        unit->AddThreat(victim, threat, false, spellEntry ? spellEntry->SchoolMask : SPELL_SCHOOL_MASK_NONE, spellEntry);
-#else
-        SpellEntry const* spellEntry = sSpellStore.LookupEntry(spell);
-#ifdef CLASSIC
-        unit->AddThreat(victim, threat, false, spellEntry ? GetSchoolMask(spellEntry->School) : SPELL_SCHOOL_MASK_NONE, spellEntry);
-#else
-        unit->AddThreat(victim, threat, false, spellEntry ? static_cast<SpellSchoolMask>(spellEntry->SchoolMask) : SPELL_SCHOOL_MASK_NONE, spellEntry);
-#endif
-#endif
-#endif
         return 0;
     }
 
@@ -3056,9 +2575,7 @@ namespace LuaUnit
         Unit* victim = Eluna::CHECKOBJ<Unit>(L, 2);
         int32 threatPct = Eluna::CHECKVAL<int32>(L, 3, true);
 
-#ifdef AZEROTHCORE
         unit->GetThreatMgr().ModifyThreatByPercent(victim, threatPct);
-#endif
         return 0;
     }
 

--- a/src/LuaEngine/UnitMethods.h
+++ b/src/LuaEngine/UnitMethods.h
@@ -1382,8 +1382,6 @@ namespace LuaUnit
     {
         uint32 type = Eluna::CHECKVAL<uint32>(L, 2);
         float rate = Eluna::CHECKVAL<float>(L, 3);
-        bool forced = Eluna::CHECKVAL<bool>(L, 4, false);
-        (void)forced; // ensure that the variable is referenced in order to pass compiler checks
         if (type >= MAX_MOVE_TYPE)
             return luaL_argerror(L, 2, "valid UnitMoveType expected");
 

--- a/src/LuaEngine/UnitMethods.h
+++ b/src/LuaEngine/UnitMethods.h
@@ -1184,7 +1184,9 @@ namespace LuaUnit
     {
         uint32 type = Eluna::CHECKVAL<uint32>(L, 2);
         if (type >= MAX_MOVE_TYPE)
+        {
             return luaL_argerror(L, 2, "valid UnitMoveType expected");
+        }
 
         Eluna::Push(L, unit->GetSpeedRate((UnitMoveType)type));
 


### PR DESCRIPTION
Fixxed: SetSpeed and GetSpeed Function
Added: SetSpeedRate and GetSpeedRate
Removed: Unnecessary Ifdef's

Foe recognized on the azerothcore mod-eluna repo that the SetSpeed function is using the wrong SetSpeedRate member of unit.

This PR changes that and seperates the functions from each other.

Also we decided to remove the ifdefs that are not needed as the module is only for azerothcore and not for Trinty or Mangos.

You can test this PR by using the functions in a script and check the impact ;) 

Thanks for your time!