### PR TITLE
Adding HandleStatModifier for Unit

### DIFF
--- a/src/LuaEngine/LuaFunctions.cpp
+++ b/src/LuaEngine/LuaFunctions.cpp
@@ -401,6 +401,7 @@ ElunaRegister<Unit> UnitMethods[] =
 #endif
 
     // Other
+    {"HandleStatModifier", &LuaUnit::HandleStatModifier},
     { "AddAura", &LuaUnit::AddAura },
     { "RemoveAura", &LuaUnit::RemoveAura },
     { "RemoveAllAuras", &LuaUnit::RemoveAllAuras },

--- a/src/LuaEngine/UnitMethods.h
+++ b/src/LuaEngine/UnitMethods.h
@@ -13,6 +13,27 @@
 namespace LuaUnit
 {
     /**
+     * The [Unit] modifies a specific stat
+     *
+     * @param int32 stat : The stat to modify
+     * @param int8 type : The type of modifier to apply
+     * @param float value : The value to apply to the stat
+     * @param bool apply = false : Whether the modifier should be applied or removed
+     * @return bool : Whether the stat modification was successful
+     */
+    int HandleStatModifier(lua_State* L, Unit* unit)
+    {
+        int32 stat = Eluna::CHECKVAL<int32>(L, 2);
+        int8  type = Eluna::CHECKVAL<int8>(L, 3);
+
+        float value = Eluna::CHECKVAL<float>(L, 4);
+        bool apply = Eluna::CHECKVAL<bool>(L, 5, false);
+
+        Eluna::Push(L, unit->HandleStatModifier(UnitMods(UNIT_MOD_STAT_START + stat), (UnitModifierType)type, value, apply));
+        return 1;
+    }
+
+    /**
      * The [Unit] tries to attack a given target
      *
      * @param [Unit] who : [Unit] to attack


### PR DESCRIPTION
Greetings,

This pull request introduces the HandleStatModifier method for Unit in the Eluna module.

Here's a brief overview of the addition:
```cpp
/**
 * The [Unit] modifies a specific stat
 *
 * @param int32 stat : The stat to modify
 * @param int8 type : The type of modifier to apply
 * @param float value : The value to apply to the stat
 * @param bool apply = false : Whether the modifier should be applied or removed
 * @return bool : Whether the stat modification was successful
 */
int HandleStatModifier(lua_State* L, Unit* unit)
{
    // Implementation...
}
```

This new method allows you to modify a specific stat of a [Unit], defining the type of modifier to apply, the value to apply to the stat, and whether the modifier should be applied or removed.

Your feedback on this addition would be greatly appreciated.
Kind Regards,

Vaiocti (iThorgrim)