### PR TITLE
Adding SetSpellPower for Player

### DIFF
--- a/src/LuaEngine/LuaFunctions.cpp
+++ b/src/LuaEngine/LuaFunctions.cpp
@@ -568,6 +568,7 @@ ElunaRegister<Player> PlayerMethods[] =
     { "SetRankPoints", &LuaPlayer::SetRankPoints },
     { "SetHonorLastWeekStandingPos", &LuaPlayer::SetHonorLastWeekStandingPos },
 #endif
+    { "SetSpellPower", &LuaPlayer::SetSpellPower },
     { "SetLifetimeKills", &LuaPlayer::SetLifetimeKills },
     { "SetGameMaster", &LuaPlayer::SetGameMaster },
     { "SetGMChat", &LuaPlayer::SetGMChat },

--- a/src/LuaEngine/PlayerMethods.h
+++ b/src/LuaEngine/PlayerMethods.h
@@ -4267,6 +4267,21 @@ namespace LuaPlayer
         return 1;
     }
 
+    /**
+     * The [Player] sets the spell power
+     *
+     * @param int value : The spell power value to set
+     * @param bool apply = false : Whether the spell power should be applied or removed
+     */
+    int SetSpellPower(lua_State* L, Player* player)
+    {
+        int value  = Eluna::CHECKVAL<int>(L, 2);
+        bool apply = Eluna::CHECKVAL<bool>(L, 3, false);
+
+        player->ApplySpellPowerBonus(value, apply);
+        return 0;
+    }
+
     /*int BindToInstance(lua_State* L, Player* player)
     {
     player->BindToInstance();


### PR DESCRIPTION
Hello,
In this pull request we are introducing the SetSpellPower method for Player in the Eluna module.

Here's a brief overview of the function:
```cpp
/**
 * The [Player] sets the spell power
 *
 * @param int value : The spell power value to set
 * @param bool apply = false : Whether the spell power should be applied or removed
 */
int SetSpellPower(lua_State* L, Player* player)
{
    // Function implementation...
}
```

This allows you to set the spell power of a [Player], indicating the spell power value to set and whether the spell power should be applied or removed.

Tests were carried out over several months on my own server.
![image](https://github.com/azerothcore/mod-eluna/assets/125808072/93ea1aa4-4ddc-470f-bab5-493c93b08d6b)

Your feedback on this addition would be greatly appreciated.
Kind Regards,

Vaiocti (iThorgrim)