### PR TITLE
Add Specialization Check Methods to Player

### DIFF
--- a/src/LuaEngine/LuaFunctions.cpp
+++ b/src/LuaEngine/LuaFunctions.cpp
@@ -593,6 +593,10 @@ ElunaRegister<Player> PlayerMethods[] =
 #endif
 
     // Boolean
+    { "HasTankSpec", &LuaPlayer::HasTankSpec },
+    { "HasMeleeSpec", &LuaPlayer::HasMeleeSpec },
+    { "HasCasterSpec", &LuaPlayer::HasCasterSpec },
+    { "HasHealSpec", &LuaPlayer::HasHealSpec },
     { "IsInGroup", &LuaPlayer::IsInGroup },
     { "IsInGuild", &LuaPlayer::IsInGuild },
     { "IsGM", &LuaPlayer::IsGM },

--- a/src/LuaEngine/PlayerMethods.h
+++ b/src/LuaEngine/PlayerMethods.h
@@ -406,6 +406,50 @@ namespace LuaPlayer
 #endif
 
     /**
+     * Returns `true` if the [Player] has a Tank Specialization, `false` otherwise.
+     *
+     * @return bool HasTankSpec
+     */
+    int HasTankSpec(lua_State* L, Player* player)
+    {
+        Eluna::Push(L, player->HasTankSpec());
+        return 1;
+    }
+    
+    /**
+     * Returns `true` if the [Player] has a Melee Specialization, `false` otherwise.
+     *
+     * @return bool HasMeleeSpec
+     */
+    int HasMeleeSpec(lua_State* L, Player* player)
+    {
+        Eluna::Push(L, player->HasMeleeSpec());
+        return 1;
+    }
+    
+    /**
+     * Returns `true` if the [Player] has a Caster Specialization, `false` otherwise.
+     *
+     * @return bool HasCasterSpec
+     */
+    int HasCasterSpec(lua_State* L, Player* player)
+    {
+        Eluna::Push(L, player->HasCasterSpec());
+        return 1;
+    }
+    
+    /**
+     * Returns `true` if the [Player] has a Heal Specialization, `false` otherwise.
+     *
+     * @return bool HasHealSpec
+     */
+    int HasHealSpec(lua_State* L, Player* player)
+    {
+        Eluna::Push(L, player->HasHealSpec());
+        return 1;
+    }
+
+    /**
      * Returns `true` if the [Player] is in a [Group], `false` otherwise.
      *
      * @return bool isInGroup


### PR DESCRIPTION
This Pull Request introduces four new methods to the Player class in order to check for a player's specialization:

- HasTankSpec: This method will return true if the player has a Tank Specialization, false otherwise.
- HasMeleeSpec: This method will return true if the player has a Melee Specialization, false otherwise.
- HasCasterSpec: This method will return true if the player has a Caster Specialization, false otherwise.
- HasHealSpec: This method will return true if the player has a Heal Specialization, false otherwise.

The code for these methods has already been tested and works as expected. You can use them by calling Player:HasTankSpec(), Player:HasMeleeSpec(), Player:HasCasterSpec(), Player:HasHealSpec() respectively.

Your feedback on this addition would be greatly appreciated.
Kind Regards,

Vaiocti (iThorgrim)