### PR TITLE
Add Spell:GetReagentCost() function

### DIFF
--- a/src/LuaEngine/LuaFunctions.cpp
+++ b/src/LuaEngine/LuaFunctions.cpp
@@ -1075,6 +1075,7 @@ ElunaRegister<Spell> SpellMethods[] =
     { "GetEntry", &LuaSpell::GetEntry },
     { "GetDuration", &LuaSpell::GetDuration },
     { "GetPowerCost", &LuaSpell::GetPowerCost },
+    { "GetReagentCost", &LuaSpell::GetReagentCost },
     { "GetTargetDest", &LuaSpell::GetTargetDest },
     { "GetTarget", &LuaSpell::GetTarget },
 

--- a/src/LuaEngine/SpellMethods.h
+++ b/src/LuaEngine/SpellMethods.h
@@ -70,6 +70,30 @@ namespace LuaSpell
     }
 
     /**
+     * Returns the reagents needed for the [Spell].
+     *
+     * @return table reagents : a table containing the [ItemTemplate]s and amount of reagents needed for the [Spell]
+    */
+    int GetReagentCost(lua_State* L, Spell* spell)
+    {
+        auto spellInfo = spell->GetSpellInfo();
+        auto reagents = spellInfo->Reagent;
+        auto reagentCounts = spellInfo->ReagentCount;
+        lua_newtable(L);
+        for (auto i = 0; i < MAX_SPELL_REAGENTS; ++i)
+        {
+            if (reagents[i] <= 0)
+                continue;
+            auto reagent = eObjectMgr->GetItemTemplate(reagents[i]);
+            auto count = reagentCounts[i];
+            Eluna::Push(L, reagent);
+            Eluna::Push(L, count);
+            lua_settable(L, -3);
+        }
+        return 1;
+    }
+
+    /**
      * Returns the spell duration of the [Spell].
      *
      * @return int32 duration


### PR DESCRIPTION
Returns a table containing the reagent cost of the spell in the format
```lua
reagents = {
    [ItemTemplate] = amount,
    [ItemTemplate] = amount,
    ...
}
```
Example usage:
```lua
local function OnSpellCast(_, player, spell, _)
    local reagents = spell:GetReagentCost()
    player:SendBroadcastMessage("You just cast " .. spell:GetEntry() .. " with the following reagents:")
    for reagent, count in pairs(reagents) do
        player:SendBroadcastMessage(string.format("%d x %s", count, reagent:GetName()))
    end
    return false
end

RegisterPlayerEvent(PLAYER_EVENT_ON_SPELL_CAST, OnSpellCast)
```