### PR TITLE
feat: add GetRank method for creatures

### DIFF
--- a/src/LuaEngine/CreatureMethods.h
+++ b/src/LuaEngine/CreatureMethods.h
@@ -957,6 +957,17 @@ auto const& threatlist = creature->GetThreatMgr().GetThreatList();
         return 1;
     }
 
+    /**
+     * Returns the [Creature]'s rank.
+     *
+     * @return [Rank] rank
+     */
+    int GetRank(lua_State* L, Creature* creature)
+    {
+        Eluna::Push(L, creature->GetCreatureTemplate()->rank);
+        return 1;
+    }
+
 #if defined(CLASSIC) || defined(TBC) || defined(WOTLK)
     /**
      * Returns the [Creature]'s shield block value.

--- a/src/LuaEngine/LuaFunctions.cpp
+++ b/src/LuaEngine/LuaFunctions.cpp
@@ -831,6 +831,7 @@ ElunaRegister<Creature> CreatureMethods[] =
     { "GetUnitFlags", &LuaCreature::GetUnitFlags },
     { "GetUnitFlagsTwo", &LuaCreature::GetUnitFlagsTwo },
     { "GetExtraFlags", &LuaCreature::GetExtraFlags },
+    { "GetRank", &LuaCreature::GetRank },
 #if defined(CLASSIC) || defined(TBC) || defined(WOTLK)
     { "GetShieldBlockValue", &LuaCreature::GetShieldBlockValue },
 #endif


### PR DESCRIPTION
Introduces the GetRank method. Rank is used in creature_template to set the rank of the creature, e.g. rare (4) or rare elite (2).

You can test this in game with this lua script:

```lua
local command = "#rank"
local function FetchCreatureRank(event, player, message, type, language)
    if message == command then
        local creature = player:GetSelection() -- Get the player's target
        
        if creature then
            local rank = creature:GetRank() -- Fetch the rank of the selected creature
            
            if rank then
                print("Creature Rank: " .. rank) -- Print the creature's rank
            else
                print("Creature rank not available.")
            end
        else
            print("No creature selected.")
        end

        return false -- Prevent the default chat behavior
    end
end
RegisterPlayerEvent(18, FetchCreatureRank)
```
If the player types "#rank" while having targeted a creature, the script will print the creature's rank to the console.