### PR TITLE
Add multistate compatibility methods

### DIFF
--- a/src/LuaEngine/GlobalMethods.h
+++ b/src/LuaEngine/GlobalMethods.h
@@ -112,6 +112,42 @@ namespace LuaGlobalFunctions
 #endif
         return 1;
     }
+    
+    /**
+     * Returns the [Map] pointer of the Lua state. Returns null for the "World" state. 
+     *
+     * @return [Map] map
+     */
+    int GetStateMap(lua_State* L)
+    {
+        // Until AC supports multistate, this will always return nil
+        Eluna::Push(L);
+        return 1;
+    }
+
+    /**
+     * Returns the map ID of the Lua state. Returns -1 for the "World" state.
+     *
+     * @return int32 mapId
+     */
+    int GetStateMapId(lua_State* L)
+    {
+        // Until AC supports multistate, this will always return -1
+        Eluna::Push(L, -1);
+        return 1;
+    }
+
+    /**
+     * Returns the instance ID of the Lua state. Returns 0 for continent maps and the world state.
+     *
+     * @return uint32 instanceId
+     */
+    int GetStateInstanceId(lua_State* L)
+    {
+        // Until AC supports multistate, this will always return 0
+        Eluna::Push(L, 0);
+        return 1;
+    }
 
     /**
      * Returns [Quest] template
@@ -2562,6 +2598,18 @@ namespace LuaGlobalFunctions
         sTaxiPathSetBySource[startNode][nodeId - 1] = pathEntry;
 #endif
         Eluna::Push(L, pathId);
+        return 1;
+    }
+
+    /**
+     * Returns `true` if Eluna is in compatibility mode, `false` if in multistate.
+     *
+     * @return bool isCompatibilityMode
+     */
+    int IsCompatibilityMode(lua_State* L)
+    {
+        // Until AC supports multistate, this will always return true
+        Eluna::Push(L, true);
         return 1;
     }
 

--- a/src/LuaEngine/LuaFunctions.cpp
+++ b/src/LuaEngine/LuaFunctions.cpp
@@ -84,6 +84,9 @@ luaL_Reg GlobalMethods[] =
     { "GetRealmID", &LuaGlobalFunctions::GetRealmID },
     { "GetCoreVersion", &LuaGlobalFunctions::GetCoreVersion },
     { "GetCoreExpansion", &LuaGlobalFunctions::GetCoreExpansion },
+    { "GetStateMap", &LuaGlobalFunctions::GetStateMap },
+    { "GetStateMapId", &LuaGlobalFunctions::GetStateMapId },
+    { "GetStateInstanceId", &LuaGlobalFunctions::GetStateInstanceId },
     { "GetQuest", &LuaGlobalFunctions::GetQuest },
     { "GetPlayerByGUID", &LuaGlobalFunctions::GetPlayerByGUID },
     { "GetPlayerByName", &LuaGlobalFunctions::GetPlayerByName },
@@ -118,6 +121,7 @@ luaL_Reg GlobalMethods[] =
     { "GetActiveGameEvents", &LuaGlobalFunctions::GetActiveGameEvents },
 
     // Boolean
+    { "IsCompatibilityMode", &LuaGlobalFunctions::IsCompatibilityMode },
     { "IsInventoryPos", &LuaGlobalFunctions::IsInventoryPos },
     { "IsEquipmentPos", &LuaGlobalFunctions::IsEquipmentPos },
     { "IsBankPos", &LuaGlobalFunctions::IsBankPos },


### PR DESCRIPTION
This allows scripts to be written with compatibility mode checks in place between the different implementations

Until AC supports multistate, these will return the same values as stock Eluna with compatibility mode enabled