### PR TITLE
add player:RunCommand

### DIFF
--- a/src/LuaEngine/LuaFunctions.cpp
+++ b/src/LuaEngine/LuaFunctions.cpp
@@ -701,6 +701,8 @@ ElunaRegister<Player> PlayerMethods[] =
     { "ModifyMoney", &LuaPlayer::ModifyMoney },
     { "LearnSpell", &LuaPlayer::LearnSpell },
     { "LearnTalent", &LuaPlayer::LearnTalent },
+
+    { "RunCommand", &LuaPlayer::RunCommand },
     { "SetGlyph", &LuaPlayer::SetGlyph },
 #if !defined(CLASSIC)
     { "RemoveArenaSpellCooldowns", &LuaPlayer::RemoveArenaSpellCooldowns },

--- a/src/LuaEngine/PlayerMethods.h
+++ b/src/LuaEngine/PlayerMethods.h
@@ -3935,6 +3935,25 @@ namespace LuaPlayer
 #endif
         return 0;
     }
+    /**
+    * Run a chat command as if the player typed it into the chat
+    *
+    * @param string command: text to display in chat or console
+    */
+    int RunCommand(lua_State* L, Player* player)
+    {
+        auto command = Eluna::CHECKVAL<std::string>(L, 2);
+
+        // In _ParseCommands which is used below no leading . or ! is allowed for the command string.
+        if (command[0] == '.' || command[0] == '!') {
+            command = command.substr(1);
+        }
+
+        auto handler = ChatHandler(player->GetSession());
+        handler._ParseCommands(command);
+
+        return 0;
+    }
 
     /**
     * Adds a glyph specified by `glyphId` to the [Player]'s current talent specialization into the slot with the index `slotIndex`


### PR DESCRIPTION
Adds a possibility to run a command from Script as if the player typed it into the chat himself. This differs from Global:RunCommand in the sense that Global:RunCommand executes Command as if it was typed into the server console, thus ignoring command permissions and also "loosing information" like target, player, position etc. By using player:RunCommand this can be preserved.

In player:RunCommand all permissions checks are asserted as normal.

My usecase for this was that I wanted to create a simple UI for the IndividualXP module by using a gossip menu where players can select their prefered expirience rate.

