### PR TITLE
feature: Add GetGlyph

### DIFF
--- a/src/LuaEngine/LuaFunctions.cpp
+++ b/src/LuaEngine/LuaFunctions.cpp
@@ -702,6 +702,7 @@ ElunaRegister<Player> PlayerMethods[] =
     { "LearnSpell", &LuaPlayer::LearnSpell },
     { "LearnTalent", &LuaPlayer::LearnTalent },
     { "SetGlyph", &LuaPlayer::SetGlyph },
+    { "GetGlyph",&LuaPlayer::GetGlyph },
 #if !defined(CLASSIC)
     { "RemoveArenaSpellCooldowns", &LuaPlayer::RemoveArenaSpellCooldowns },
 #endif

--- a/src/LuaEngine/LuaFunctions.cpp
+++ b/src/LuaEngine/LuaFunctions.cpp
@@ -702,7 +702,7 @@ ElunaRegister<Player> PlayerMethods[] =
     { "LearnSpell", &LuaPlayer::LearnSpell },
     { "LearnTalent", &LuaPlayer::LearnTalent },
     { "SetGlyph", &LuaPlayer::SetGlyph },
-    { "GetGlyph",&LuaPlayer::GetGlyph },
+    { "GetGlyph", &LuaPlayer::GetGlyph },
 #if !defined(CLASSIC)
     { "RemoveArenaSpellCooldowns", &LuaPlayer::RemoveArenaSpellCooldowns },
 #endif

--- a/src/LuaEngine/PlayerMethods.h
+++ b/src/LuaEngine/PlayerMethods.h
@@ -3956,6 +3956,7 @@ namespace LuaPlayer
     /**
     * Get glyphId off glyph slot specified by `slotIndex` off the [Player]'s current talent specialization.`
     * @param uint32 slotIndex
+    * @return glyphId off the glyph in the selected glyphSlot or 0 in case the glyph slot is empty
     */
     int GetGlyph(lua_State* L, Player* player)
     {

--- a/src/LuaEngine/PlayerMethods.h
+++ b/src/LuaEngine/PlayerMethods.h
@@ -3954,7 +3954,7 @@ namespace LuaPlayer
     }
 
     /**
-    * Get glyphId off glyph slot specified by `slotIndex` off the [Player]'s current talent specialization.`
+    * Get glyphId of the glyph slot specified by `slotIndex` off the [Player]'s current talent specialization.`
     * @param uint32 slotIndex
     * @return glyphId of the glyph in the selected glyph slot or 0 in case the glyph slot is empty
     */

--- a/src/LuaEngine/PlayerMethods.h
+++ b/src/LuaEngine/PlayerMethods.h
@@ -3956,7 +3956,7 @@ namespace LuaPlayer
     /**
     * Get glyphId off glyph slot specified by `slotIndex` off the [Player]'s current talent specialization.`
     * @param uint32 slotIndex
-    * @return glyphId off the glyph in the selected glyphSlot or 0 in case the glyph slot is empty
+    * @return glyphId of the glyph in the selected glyph slot or 0 in case the glyph slot is empty
     */
     int GetGlyph(lua_State* L, Player* player)
     {

--- a/src/LuaEngine/PlayerMethods.h
+++ b/src/LuaEngine/PlayerMethods.h
@@ -3953,6 +3953,17 @@ namespace LuaPlayer
         return 0;
     }
 
+    /**
+    * Get glyphId off glyph slot specified by `slotIndex` off the [Player]'s current talent specialization.`
+    * @param uint32 slotIndex
+    */
+    int GetGlyph(lua_State* L, Player* player)
+    {
+        auto slotIndex = Eluna::CHECKVAL<uint32>(L, 2);
+        Eluna::Push(L,player->GetGlyph(slotIndex));
+        return 1;
+    }
+
 #if !defined(CLASSIC)
     /**
      * Remove cooldowns on spells that have less than 10 minutes of cooldown from the [Player], similarly to when you enter an arena.


### PR DESCRIPTION
adds player:GetGlyph(slotIndex) (requested by @55Honey in https://github.com/azerothcore/mod-eluna/issues/152#issuecomment-1669529044_)

### how to test
add a scripting file with:
``` lua
local function OnPlayerCommand(event, player, command)
  if (command == "add_glyph") then
        print("reached_command: add glyph")
        player:SetGlyph(190,0)
        player:SetGlyph(702,3)

        player:Say("glyph in slot 0: "..player:GetGlyph(0),0)

        player:Say("glyph in slot 1: "..player:GetGlyph(1),0)

        player:Say("glyph in slot 3: "..player:GetGlyph(3),0)
        return false
    end
end

RegisterPlayerEvent(42, OnPlayerCommand)
```

On a paladin execute command ".add_glyph" in chat
Check that output matches input as written in script (190,0,702)

also credit to @kissingers who created a PR on this topics on the same day. https://github.com/azerothcore/mod-eluna/pull/177