### PR TITLE
Fix gossip menu item overflow

### DIFF
--- a/src/LuaEngine/PlayerMethods.h
+++ b/src/LuaEngine/PlayerMethods.h
@@ -4043,7 +4043,8 @@ namespace LuaPlayer
         {
             player->PlayerTalkClass->GetGossipMenu().AddMenuItem(-1, _icon, msg, _sender, _intid, _promptMsg, _money,
                                                                  _code);
-        } else
+        }
+        else
         {
             return luaL_error(L, "GossipMenuItem not added. Reached Max amount of possible GossipMenuItems in this GossipMenu");
         }

--- a/src/LuaEngine/PlayerMethods.h
+++ b/src/LuaEngine/PlayerMethods.h
@@ -8,6 +8,7 @@
 #define PLAYERMETHODS_H
 
 #include "GameTime.h"
+#include "GossipDef.h"
 
 /***
  * Inherits all methods from: [Object], [WorldObject], [Unit]

--- a/src/LuaEngine/PlayerMethods.h
+++ b/src/LuaEngine/PlayerMethods.h
@@ -4008,10 +4008,12 @@ namespace LuaPlayer
         const char* _promptMsg = Eluna::CHECKVAL<const char*>(L, 7, "");
         uint32 _money = Eluna::CHECKVAL<uint32>(L, 8, 0);
 #if defined TRINITY || AZEROTHCORE
-        if (player->PlayerTalkClass->GetGossipMenu().GetMenuItemCount() < GOSSIP_MAX_MENU_ITEMS) {
+        if (player->PlayerTalkClass->GetGossipMenu().GetMenuItemCount() < GOSSIP_MAX_MENU_ITEMS)
+        {
             player->PlayerTalkClass->GetGossipMenu().AddMenuItem(-1, _icon, msg, _sender, _intid, _promptMsg, _money,
                                                                  _code);
-        } else {
+        } else
+        {
             return luaL_error(L, "GossipMenuItem not added. Reached Max amount of possible GossipMenuItems in this GossipMenu");
         }
 #else

--- a/src/LuaEngine/PlayerMethods.h
+++ b/src/LuaEngine/PlayerMethods.h
@@ -4012,7 +4012,7 @@ namespace LuaPlayer
             player->PlayerTalkClass->GetGossipMenu().AddMenuItem(-1, _icon, msg, _sender, _intid, _promptMsg, _money,
                                                                  _code);
         } else {
-            return luaL_error(L, "GossipMenuItem not added. Reached Max amount of possible GossipMenuItems.");
+            return luaL_error(L, "GossipMenuItem not added. Reached Max amount of possible GossipMenuItems in this GossipMenu");
         }
 #else
 #ifndef CLASSIC

--- a/src/LuaEngine/PlayerMethods.h
+++ b/src/LuaEngine/PlayerMethods.h
@@ -4007,7 +4007,12 @@ namespace LuaPlayer
         const char* _promptMsg = Eluna::CHECKVAL<const char*>(L, 7, "");
         uint32 _money = Eluna::CHECKVAL<uint32>(L, 8, 0);
 #if defined TRINITY || AZEROTHCORE
-        player->PlayerTalkClass->GetGossipMenu().AddMenuItem(-1, _icon, msg, _sender, _intid, _promptMsg, _money, _code);
+        if (player->PlayerTalkClass->GetGossipMenu().GetMenuItemCount() < GOSSIP_MAX_MENU_ITEMS) {
+            player->PlayerTalkClass->GetGossipMenu().AddMenuItem(-1, _icon, msg, _sender, _intid, _promptMsg, _money,
+                                                                 _code);
+        } else {
+            return luaL_error(L, "GossipMenuItem not added. Reached Max amount of possible GossipMenuItems.");
+        }
 #else
 #ifndef CLASSIC
         player->PlayerTalkClass->GetGossipMenu().AddMenuItem(_icon, msg, _sender, _intid, _promptMsg, _money, _code);


### PR DESCRIPTION
closes https://github.com/azerothcore/mod-eluna/issues/118

How to Test: 
use this code to verify server doesn't crash after attempting to add more than 32 GossipMenuItems
``` lua
local function hello(event, player, object)
    for n = 1, 40, 1 do
        player:GossipMenuAddItem(1, "Text "..n, 20124, n)
        print("added: "..n)
    end
    player:GossipSendMenu(0, object, 0)
end

RegisterCreatureGossipEvent(20124, 1, hello)

```
(Code copied from @55Honey in the issue linked above)


Expected Output in world-server console:
![grafik](https://github.com/azerothcore/mod-eluna/assets/76077537/7ca87628-85ce-409a-97c7-ae1ce3c4e90c)

