### PR TITLE
Fix unused variable warning in GlobalMethods:Ban()

### DIFF
--- a/src/LuaEngine/GlobalMethods.h
+++ b/src/LuaEngine/GlobalMethods.h
@@ -2160,6 +2160,7 @@ namespace LuaGlobalFunctions
         const int BAN_IP = 2;
 
         BanMode mode = BanMode::BAN_ACCOUNT;
+        (void)mode; // ensure that the variable is referenced in order to pass compiler checks
 
         switch (banMode)
         {


### PR DESCRIPTION
- this has been done everywhere in mod-eluna already to compensate the #if-blocks for different cores
- just a quick fix to get rid of CI warnings so AC module build will pass again