### PR TITLE
Update WorldPacketMethods.h

### DIFF
--- a/src/LuaEngine/WorldPacketMethods.h
+++ b/src/LuaEngine/WorldPacketMethods.h
@@ -166,12 +166,13 @@ namespace LuaPacket
      * @return ObjectGuid value : value returned as string
      */
     int ReadGUID(lua_State* L, WorldPacket* packet)
-    {
-        ObjectGuid guid;
-        (*packet) >> guid;
-        Eluna::Push(L, guid);
-        return 1;
-    }
+{
+    uint64 guid;
+    packet->readPackGUID(guid);
+    Eluna::Push(L, guid);
+    return 1;
+}
+
 
     /**
      * Reads and returns a string value from the [WorldPacket].


### PR DESCRIPTION
The GUID is incorrect, it was read without going through the buffer.Sometings crash.

int ReadGUID(lua_State* L, WorldPacket* packet)
{
ObjectGuid guid;
(*packet) >> guid;
Eluna::Push(L, guid);
return 1;
}

The following code works correctly:

int ReadGUID(lua_State* L, WorldPacket* packet)
{
uint64 guid;
packet->readPackGUID(guid);
Eluna::Push(L, guid);
return 1;
}