### PR TITLE
sprintf to snprintf (deprecated  MacOSX15.0)

### DIFF
--- a/src/LuaEngine/ElunaQueryMethods.h
+++ b/src/LuaEngine/ElunaQueryMethods.h
@@ -29,7 +29,7 @@ namespace LuaQuery
         if (field >= count)
         {
             char arr[256];
-            sprintf(arr, "trying to access invalid field index %u. There are %u fields available and the indexes start from 0", field, count);
+            snprintf(arr, sizeof(arr), "trying to access invalid field index %u. There are %u fields available and the indexes start from 0", field, count);
             luaL_argerror(L, 2, arr);
         }
     }


### PR DESCRIPTION
```
In file included from modules/mod-eluna/src/LuaEngine/LuaFunctions.cpp:29:
modules/mod-eluna/src/LuaEngine/ElunaQueryMethods.h:32:13: warning: 'sprintf' is deprecated: This function is provided for compatibility reasons only.  Due to security concerns inherent in the design of sprintf(3), it is highly recommended that you use snprintf(3) instead. [-Wdeprecated-declarations]
   32 |             sprintf(arr, "trying to access invalid field index %u. There are %u fields available and the indexes start from 0", field, count);
      |             ^
/Library/Developer/CommandLineTools/SDKs/MacOSX15.0.sdk/usr/include/_stdio.h:274:1: note: 'sprintf' has been explicitly marked deprecated here
  274 | __deprecated_msg("This function is provided for compatibility reasons only.  Due to security concerns inherent in the design of sprintf(3), it is highly recommended that you use snprintf(3) instead.")
      | ^
/Library/Developer/CommandLineTools/SDKs/MacOSX15.0.sdk/usr/include/sys/cdefs.h:218:48: note: expanded from macro '__deprecated_msg'
  218 |         #define __deprecated_msg(_msg) __attribute__((__deprecated__(_msg)))
      |
```