### PR TITLE
Feat: Add support for parameterized SQL queries with argument escaping

### DIFF
--- a/src/LuaEngine/LuaEngine.cpp
+++ b/src/LuaEngine/LuaEngine.cpp
@@ -690,6 +690,48 @@ void Eluna::Push(lua_State* luastate, ObjectGuid const guid)
     ElunaTemplate<unsigned long long>::Push(luastate, new unsigned long long(guid.GetRawValue()));
 }
 
+std::string Eluna::FormatQuery(lua_State* L, const char* query)
+{
+    int numArgs = lua_gettop(L);
+    std::string formattedQuery = query;
+
+    size_t position = 0;
+    for (int i = 2; i <= numArgs; ++i) 
+    {
+        std::string arg;
+
+        if (lua_isnumber(L, i)) 
+        {
+            arg = std::to_string(lua_tonumber(L, i));
+        } 
+        else if (lua_isstring(L, i)) 
+        {
+            std::string value = lua_tostring(L, i);
+            for (size_t pos = 0; (pos = value.find('\'', pos)) != std::string::npos; pos += 2)
+            {
+                value.insert(pos, "'");
+            }
+            arg = "'" + value + "'";
+        } 
+        else 
+        {
+            luaL_error(L, "Unsupported argument type. Only numbers and strings are supported.");
+            return "";
+        }
+
+        position = formattedQuery.find("?", position);
+        if (position == std::string::npos) 
+        {
+            luaL_error(L, "Mismatch between placeholders and arguments.");
+            return "";
+        }
+        formattedQuery.replace(position, 1, arg);
+        position += arg.length();
+    }
+
+    return formattedQuery;
+}
+
 static int CheckIntegerRange(lua_State* luastate, int narg, int min, int max)
 {
     double value = luaL_checknumber(luastate, narg);

--- a/src/LuaEngine/LuaEngine.h
+++ b/src/LuaEngine/LuaEngine.h
@@ -261,6 +261,8 @@ public:
     {
         ElunaTemplate<T>::Push(luastate, ptr);
     }
+    
+    static std::string FormatQuery(lua_State* L, const char* query);
 
     bool ExecuteCall(int params, int res);
 

--- a/src/LuaEngine/methods/GlobalMethods.h
+++ b/src/LuaEngine/methods/GlobalMethods.h
@@ -1311,6 +1311,10 @@ namespace LuaGlobalFunctions
     {
         const char* query = Eluna::CHECKVAL<const char*>(L, 1);
 
+        int numArgs = lua_gettop(L);
+        if (numArgs > 1)
+            query = Eluna::FormatQuery(L, query).c_str();
+
         ElunaQuery result = WorldDatabase.Query(query);
         if (result)
             Eluna::Push(L, new ElunaQuery(result));
@@ -1359,6 +1363,11 @@ namespace LuaGlobalFunctions
     int WorldDBExecute(lua_State* L)
     {
         const char* query = Eluna::CHECKVAL<const char*>(L, 1);
+
+        int numArgs = lua_gettop(L);
+        if (numArgs > 1)
+            query = Eluna::FormatQuery(L, query).c_str();
+
         WorldDatabase.Execute(query);
         return 0;
     }
@@ -1378,6 +1387,10 @@ namespace LuaGlobalFunctions
     int CharDBQuery(lua_State* L)
     {
         const char* query = Eluna::CHECKVAL<const char*>(L, 1);
+
+        int numArgs = lua_gettop(L);
+        if (numArgs > 1)
+            query = Eluna::FormatQuery(L, query).c_str();
 
         QueryResult result = CharacterDatabase.Query(query);
         if (result)
@@ -1420,6 +1433,11 @@ namespace LuaGlobalFunctions
     int CharDBExecute(lua_State* L)
     {
         const char* query = Eluna::CHECKVAL<const char*>(L, 1);
+
+        int numArgs = lua_gettop(L);
+        if (numArgs > 1)
+            query = Eluna::FormatQuery(L, query).c_str();
+
         CharacterDatabase.Execute(query);
         return 0;
     }
@@ -1439,6 +1457,10 @@ namespace LuaGlobalFunctions
     int AuthDBQuery(lua_State* L)
     {
         const char* query = Eluna::CHECKVAL<const char*>(L, 1);
+
+        int numArgs = lua_gettop(L);
+        if (numArgs > 1)
+            query = Eluna::FormatQuery(L, query).c_str();
 
         QueryResult result = LoginDatabase.Query(query);
         if (result)
@@ -1481,6 +1503,11 @@ namespace LuaGlobalFunctions
     int AuthDBExecute(lua_State* L)
     {
         const char* query = Eluna::CHECKVAL<const char*>(L, 1);
+
+        int numArgs = lua_gettop(L);
+        if (numArgs > 1)
+            query = Eluna::FormatQuery(L, query).c_str();
+            
         LoginDatabase.Execute(query);
         return 0;
     }


### PR DESCRIPTION
This pull request introduces a new feature to Eluna, enabling parameterized SQL queries with proper handling of arguments passed from Lua.

## Key Changes:
1. **Parameterized Query Support:**
   - Allows flexible execution of SQL queries with placeholders (`?`).
   - Automatically replaces placeholders with arguments provided in Lua, ensuring correct formatting.
2. **Escaping Strings:**
   - Properly escapes single quotes (`'`) in string arguments to prevent SQL syntax errors.
   - Handles cases like strings containing special characters (e.g., "Rhahk'Zor" is safely transformed into 'Rhahk''Zor').
3. **Optional Usage:**
   - This feature is optional, and developers can still write and execute raw SQL queries without using parameterized placeholders if they prefer.

## Test performed :
```lua
-- Function to print query results
local function PrintQueryResult(query)
    if query then
        repeat
            local name = query:GetString(0)
            print("Creature Name: ", name)
        until not query:NextRow()
    else
        print("No results found.")
    end
end

-- Test with a single argument
local result1 = WorldDBQuery("SELECT `name` FROM `creature_template` WHERE name = ?", "Hogger")
PrintQueryResult(result1)
-- Creature Name: Hogger

-- Test with a single argument containing an apostrophe
local result2 = WorldDBQuery("SELECT `name` FROM `creature_template` WHERE name = ?", "Rhahk'Zor")
PrintQueryResult(result2)
-- Creature Name: Rhahk'Zor

-- Test with multiple arguments
local result3 = WorldDBQuery("SELECT `name` FROM `creature_template` WHERE name = ? AND entry = ?", "Hogger", 448)
PrintQueryResult(result3)
-- Creature Name: Hogger

-- Test with multiple arguments, including an apostrophe
local result4 = WorldDBQuery("SELECT `name` FROM `creature_template` WHERE name = ? AND entry = ?", "Rhahk'Zor", 644)
PrintQueryResult(result4)
-- Creature Name: Rhahk'Zor
```