### PR TITLE
Feat(LuaEngine/SpellHooks): Add support for RegisterSpellEvent with initial events

### DIFF
--- a/src/ElunaLuaEngine_SC.cpp
+++ b/src/ElunaLuaEngine_SC.cpp
@@ -695,7 +695,7 @@ public:
 
     void OnSpellCast(Player* player, Spell* spell, bool skipCheck) override
     {
-        sEluna->OnSpellCast(player, spell, skipCheck);
+        sEluna->OnPlayerSpellCast(player, spell, skipCheck);
     }
 
     void OnLogin(Player* player) override
@@ -854,6 +854,21 @@ public:
     void OnDummyEffect(WorldObject* caster, uint32 spellID, SpellEffIndex effIndex, Item* itemTarget) override
     {
         sEluna->OnDummyEffect(caster, spellID, effIndex, itemTarget);
+    }
+
+    void OnSpellCastCancel(Spell* spell, Unit* caster, SpellInfo const* spellInfo, bool bySelf) override
+    {
+        sEluna->OnSpellCastCancel(caster, spell, spellInfo, bySelf);
+    }
+
+    void OnSpellCast(Spell* spell, Unit* caster, SpellInfo const* spellInfo, bool skipCheck) override
+    {
+        sEluna->OnSpellCast(caster, spell, spellInfo, skipCheck);
+    }
+
+    void OnSpellPrepare(Spell* spell, Unit* caster, SpellInfo const* spellInfo) override
+    {
+        sEluna->OnSpellPrepare(caster, spell, spellInfo);
     }
 };
 

--- a/src/LuaEngine/Hooks.h
+++ b/src/LuaEngine/Hooks.h
@@ -86,6 +86,7 @@ namespace Hooks
         REGTYPE_BG,
         REGTYPE_MAP,
         REGTYPE_INSTANCE,
+        REGTYPE_SPELL,
         REGTYPE_COUNT
     };
 
@@ -364,6 +365,14 @@ namespace Hooks
         INSTANCE_EVENT_ON_GAMEOBJECT_CREATE             = 6,    // (event, instance_data, map, go)
         INSTANCE_EVENT_ON_CHECK_ENCOUNTER_IN_PROGRESS   = 7,    // (event, instance_data, map)
         INSTANCE_EVENT_COUNT
+    };
+
+    enum SpellEvents
+    {
+        SPELL_EVENT_ON_PREPARE                          = 1, // (event, caster, spell)
+        SPELL_EVENT_ON_CAST                             = 2, // (event, caster, spell, skipCheck)
+        SPELL_EVENT_ON_CAST_CANCEL                      = 3, // (event, caster, spell, bySelf)
+        SPELL_EVENT_COUNT
     };
 };
 

--- a/src/LuaEngine/LuaEngine.h
+++ b/src/LuaEngine/LuaEngine.h
@@ -216,6 +216,7 @@ public:
     BindingMap< EntryKey<Hooks::GossipEvents> >*     PlayerGossipBindings;
     BindingMap< EntryKey<Hooks::InstanceEvents> >*   MapEventBindings;
     BindingMap< EntryKey<Hooks::InstanceEvents> >*   InstanceEventBindings;
+    BindingMap< EntryKey<Hooks::SpellEvents> >*      SpellEventBindings;
 
     BindingMap< UniqueObjectKey<Hooks::CreatureEvents> >*  CreatureUniqueBindings;
 
@@ -421,7 +422,7 @@ public:
     bool OnChat(Player* pPlayer, uint32 type, uint32 lang, std::string& msg, Player* pReceiver);
     void OnEmote(Player* pPlayer, uint32 emote);
     void OnTextEmote(Player* pPlayer, uint32 textEmote, uint32 emoteNum, ObjectGuid guid);
-    void OnSpellCast(Player* pPlayer, Spell* pSpell, bool skipCheck);
+    void OnPlayerSpellCast(Player* pPlayer, Spell* pSpell, bool skipCheck);
     void OnLogin(Player* pPlayer);
     void OnLogout(Player* pPlayer);
     void OnCreate(Player* pPlayer);
@@ -520,6 +521,11 @@ public:
     void OnBGEnd(BattleGround* bg, BattleGroundTypeId bgId, uint32 instanceId, TeamId winner);
     void OnBGCreate(BattleGround* bg, BattleGroundTypeId bgId, uint32 instanceId);
     void OnBGDestroy(BattleGround* bg, BattleGroundTypeId bgId, uint32 instanceId);
+
+    /* Spell */
+    void OnSpellPrepare(Unit* caster, Spell* spell, SpellInfo const* spellInfo);
+    void OnSpellCast(Unit* caster, Spell* spell, SpellInfo const* spellInfo, bool skipCheck);
+    void OnSpellCastCancel(Unit* caster, Spell* spell, SpellInfo const* spellInfo, bool bySelf);
 };
 template<> Unit* Eluna::CHECKOBJ<Unit>(lua_State* L, int narg, bool error);
 template<> Object* Eluna::CHECKOBJ<Object>(lua_State* L, int narg, bool error);

--- a/src/LuaEngine/LuaFunctions.cpp
+++ b/src/LuaEngine/LuaFunctions.cpp
@@ -60,6 +60,7 @@ luaL_Reg GlobalMethods[] =
     { "RegisterBGEvent", &LuaGlobalFunctions::RegisterBGEvent },
     { "RegisterMapEvent", &LuaGlobalFunctions::RegisterMapEvent },
     { "RegisterInstanceEvent", &LuaGlobalFunctions::RegisterInstanceEvent },
+    { "RegisterSpellEvent", &LuaGlobalFunctions::RegisterSpellEvent },
 
     { "ClearBattleGroundEvents", &LuaGlobalFunctions::ClearBattleGroundEvents },
     { "ClearCreatureEvents", &LuaGlobalFunctions::ClearCreatureEvents },
@@ -77,6 +78,7 @@ luaL_Reg GlobalMethods[] =
     { "ClearServerEvents", &LuaGlobalFunctions::ClearServerEvents },
     { "ClearMapEvents", &LuaGlobalFunctions::ClearMapEvents },
     { "ClearInstanceEvents", &LuaGlobalFunctions::ClearInstanceEvents },
+    { "ClearSpellEvents", &LuaGlobalFunctions::ClearSpellEvents },
 
     // Getters
     { "GetLuaEngine", &LuaGlobalFunctions::GetLuaEngine },

--- a/src/LuaEngine/hooks/PlayerHooks.cpp
+++ b/src/LuaEngine/hooks/PlayerHooks.cpp
@@ -328,7 +328,7 @@ void Eluna::OnTextEmote(Player* pPlayer, uint32 textEmote, uint32 emoteNum, Obje
     CallAllFunctions(PlayerEventBindings, key);
 }
 
-void Eluna::OnSpellCast(Player* pPlayer, Spell* pSpell, bool skipCheck)
+void Eluna::OnPlayerSpellCast(Player* pPlayer, Spell* pSpell, bool skipCheck)
 {
     START_HOOK(PLAYER_EVENT_ON_SPELL_CAST);
     Push(pPlayer);

--- a/src/LuaEngine/hooks/SpellHooks.cpp
+++ b/src/LuaEngine/hooks/SpellHooks.cpp
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) 2010 - 2016 Eluna Lua Engine <http://emudevs.com/>
+ * This program is free software licensed under GPL version 3
+ * Please see the included DOCS/LICENSE.md for more information
+ */
+
+#include "Hooks.h"
+#include "HookHelpers.h"
+#include "LuaEngine.h"
+#include "BindingMap.h"
+#include "ElunaIncludes.h"
+#include "ElunaTemplate.h"
+
+using namespace Hooks;
+
+#define START_HOOK(EVENT, ENTRY) \
+    if (!IsEnabled())\
+        return;\
+    auto key = EntryKey<SpellEvents>(EVENT, ENTRY);\
+    if (!SpellEventBindings->HasBindingsFor(key))\
+        return;\
+    LOCK_ELUNA
+
+#define START_HOOK_WITH_RETVAL(EVENT, ENTRY, RETVAL) \
+    if (!IsEnabled())\
+        return RETVAL;\
+    auto key = EntryKey<SpellEvents>(EVENT, ENTRY);\
+    if (!SpellEventBindings->HasBindingsFor(key))\
+        return RETVAL;\
+    LOCK_ELUNA
+
+void Eluna::OnSpellCastCancel(Unit* caster, Spell* spell, SpellInfo const* spellInfo, bool bySelf)
+{
+    START_HOOK(SPELL_EVENT_ON_CAST_CANCEL, spellInfo->Id);
+    Push(caster);
+    Push(spell);
+    Push(bySelf);
+
+    CallAllFunctions(SpellEventBindings, key);
+}
+
+void Eluna::OnSpellCast(Unit* caster, Spell* spell, SpellInfo const* spellInfo, bool skipCheck)
+{
+    START_HOOK(SPELL_EVENT_ON_CAST, spellInfo->Id);
+    Push(caster);
+    Push(spell);
+    Push(skipCheck);
+
+    CallAllFunctions(SpellEventBindings, key);
+}
+
+void Eluna::OnSpellPrepare(Unit* caster, Spell* spell, SpellInfo const* spellInfo)
+{
+    START_HOOK(SPELL_EVENT_ON_PREPARE, spellInfo->Id);
+    Push(caster);
+    Push(spell);
+
+    CallAllFunctions(SpellEventBindings, key);
+}
+

--- a/src/LuaEngine/methods/GlobalMethods.h
+++ b/src/LuaEngine/methods/GlobalMethods.h
@@ -1216,6 +1216,29 @@ namespace LuaGlobalFunctions
     }
 
     /**
+     * Registers a [Spell] event handler.
+     *
+     * <pre>
+     * enum SpellEvents
+     * {
+     *     SPELL_EVENT_ON_PREPARE                          = 1, // (event, caster, spell)
+     *     SPELL_EVENT_ON_CAST                             = 2, // (event, caster, spell, skipCheck)
+     *     SPELL_EVENT_ON_CAST_CANCEL                      = 3, // (event, caster, spell, bySelf)
+     *     SPELL_EVENT_COUNT
+     * };
+     * </pre>
+     *
+     * @param uint32 entry : [Spell] entry Id
+     * @param uint32 event : event ID, refer to SpellEvents above
+     * @param function function : function to register
+     * @param uint32 shots = 0 : the number of times the function will be called, 0 means "always call this function"
+     */
+    int RegisterSpellEvent(lua_State* L)
+    {
+        return RegisterEntryHelper(L, Hooks::REGTYPE_SPELL);
+    }
+
+    /**
      * Reloads the Lua engine.
      */
     int ReloadEluna(lua_State* /*L*/)
@@ -3090,6 +3113,40 @@ namespace LuaGlobalFunctions
             Eluna::GetEluna(L)->InstanceEventBindings->Clear(Key((Hooks::InstanceEvents)event_type, entry));
         }
 
+        return 0;
+    }
+
+    /**
+     * Unbinds event handlers for either all of a [Spell]'s events, or one type of event.
+     *
+     * If `event_type` is `nil`, all the [Spell]'s event handlers are cleared.
+     *
+     * Otherwise, only event handlers for `event_type` are cleared.
+     *
+     *
+     * @proto (entry)
+     * @proto (entry, event_type)
+     * @param uint32 entry : the ID of a [Spell]s
+     * @param uint32 event_type : the event whose handlers will be cleared, see [Global:RegisterSpellEvent]
+     */
+    int ClearSpellEvents(lua_State* L)
+    {
+        typedef EntryKey<Hooks::SpellEvents> Key;
+
+        if (lua_isnoneornil(L, 2))
+        {
+            uint32 entry = Eluna::CHECKVAL<uint32>(L, 1);
+
+            Eluna* E = Eluna::GetEluna(L);
+            for (uint32 i = 1; i < Hooks::SPELL_EVENT_COUNT; ++i)
+                E->SpellEventBindings->Clear(Key((Hooks::SpellEvents)i, entry));
+        }
+        else
+        {
+            uint32 entry = Eluna::CHECKVAL<uint32>(L, 1);
+            uint32 event_type = Eluna::CHECKVAL<uint32>(L, 2);
+            Eluna::GetEluna(L)->SpellEventBindings->Clear(Key((Hooks::SpellEvents)event_type, entry));
+        }
         return 0;
     }
 


### PR DESCRIPTION
This pull request integrates the `RegisterSpellEvent` system from the [TrinityCore version of Eluna](https://github.com/ElunaLuaEngine/Eluna/commit/c952ad5596f5333dfa92e475537882cf838a7258) into AzerothCore, allowing scripts to handle specific spell-related events.

### Supported Events  
1. **`SPELL_EVENT_ON_PREPARE`**  
   Triggered when a spell is prepared.  
   **Signature**: `(event, caster, spell)`

2. **`SPELL_EVENT_ON_CAST`**  
   Triggered when a spell is cast.  
   **Signature**: `(event, caster, spell, skipCheck)`

3. **`SPELL_EVENT_ON_CAST_CANCEL`**  
   Triggered when a spell cast is canceled.  
   **Signature**: `(event, caster, spell, bySelf)`

### Example Usage  
```lua
lcoal SPELL_EVENT_ON_PREPARE = 1

local function OnSpellPrepare(event, caster, spell)
    print("RegisterSpellEvent :: OnPrepare")
end

RegisterSpellEvent(133, SPELL_EVENT_ON_PREPARE, OnSpellPrepare)
```

## Test performed :
```lua
SPELL_EVENT_ON_PREPARE = 1
SPELL_EVENT_ON_CAST = 2
SPELL_EVENT_ON_CAST_CANCEL = 3

-- Test function for SPELL_EVENT_ON_PREPARE
local function OnSpellPrepare(event, caster, spell)
    print("Test: OnPrepare triggered for spell ID:", spell:GetEntry())
end

-- Test function for SPELL_EVENT_ON_CAST
local function OnSpellCast(event, caster, spell, skipCheck)
    print("Test: OnCast triggered for spell ID:", spell:GetEntry(), "SkipCheck:", skipCheck)
end

-- Test function for SPELL_EVENT_ON_CAST_CANCEL
local function OnSpellCastCancel(event, caster, spell, bySelf)
    print("Test: OnCastCancel triggered for spell ID:", spell:GetEntry(), "Cancelled by self:", bySelf)
end

-- Register events for Fireball (ID: 133)
RegisterSpellEvent(133, SPELL_EVENT_ON_PREPARE, OnSpellPrepare)
RegisterSpellEvent(133, SPELL_EVENT_ON_CAST, OnSpellCast)
RegisterSpellEvent(133, SPELL_EVENT_ON_CAST_CANCEL, OnSpellCastCancel)
```

**Results:**
![image](https://github.com/user-attachments/assets/f12a2978-d0fe-4dab-956d-5fdbb4240c62)

https://github.com/user-attachments/assets/8cc8db76-175c-436f-93dc-a7f93b434c27