### PR TITLE
Feat(LuaEngine): Add RegisterTicketEvent and TicketMethods

### DIFF
--- a/src/ElunaLuaEngine_SC.cpp
+++ b/src/ElunaLuaEngine_SC.cpp
@@ -993,6 +993,32 @@ public:
     }
 };
 
+class Eluna_TicketScript : public TicketScript
+{
+public:
+    Eluna_TicketScript() : TicketScript("Eluna_TicketScript") { }
+
+    void OnTicketCreate(Player* player, GmTicket* ticket) override
+    {
+        sEluna->OnTicketCreate(player, ticket);
+    }
+
+    void OnTicketUpdate(Player* player, GmTicket* ticket) override
+    {
+        sEluna->OnTicketUpdate(player, ticket);
+    }
+
+    void OnTicketClose(Player* player, GmTicket* ticket) override
+    {
+        sEluna->OnTicketClose(player, ticket);
+    }
+
+    void OnTicketResolve(Player* player, GmTicket* ticket) override
+    {
+        sEluna->OnTicketResolve(player, ticket);
+    }
+};
+
 // Group all custom scripts
 void AddSC_ElunaLuaEngine()
 {
@@ -1013,6 +1039,7 @@ void AddSC_ElunaLuaEngine()
     new Eluna_PlayerScript();
     new Eluna_ServerScript();
     new Eluna_SpellSC();
+    new Eluna_TicketScript();
     new Eluna_UnitScript();
     new Eluna_VehicleScript();
     new Eluna_WorldObjectScript();

--- a/src/LuaEngine/Hooks.h
+++ b/src/LuaEngine/Hooks.h
@@ -86,6 +86,7 @@ namespace Hooks
         REGTYPE_BG,
         REGTYPE_MAP,
         REGTYPE_INSTANCE,
+        REGTYPE_TICKET,
         REGTYPE_COUNT
     };
 
@@ -364,6 +365,16 @@ namespace Hooks
         INSTANCE_EVENT_ON_GAMEOBJECT_CREATE             = 6,    // (event, instance_data, map, go)
         INSTANCE_EVENT_ON_CHECK_ENCOUNTER_IN_PROGRESS   = 7,    // (event, instance_data, map)
         INSTANCE_EVENT_COUNT
+    };
+
+    enum TicketEvents
+    {
+        TICKET_EVENT_ON_CREATE                          = 1,    // (event, player, ticket)
+        TICKET_EVENT_ON_UPDATE                          = 2,    // (event, player, ticket, message)
+        TICKET_EVENT_ON_CLOSE                           = 3,    // (event, player, ticket)
+        TICKET_EVENT_STATUS_UPDATE                      = 4,    // (event, player, ticket)
+        TICKET_EVENT_ON_RESOLVE                         = 5,    // (event, player, ticket)
+        TICKET_EVENT_COUNT
     };
 };
 

--- a/src/LuaEngine/LuaEngine.cpp
+++ b/src/LuaEngine/LuaEngine.cpp
@@ -159,6 +159,7 @@ ItemGossipBindings(NULL),
 PlayerGossipBindings(NULL),
 MapEventBindings(NULL),
 InstanceEventBindings(NULL),
+TicketEventBindings(NULL),
 
 CreatureUniqueBindings(NULL)
 {
@@ -242,6 +243,7 @@ void Eluna::CreateBindStores()
     GroupEventBindings       = new BindingMap< EventKey<Hooks::GroupEvents> >(L);
     VehicleEventBindings     = new BindingMap< EventKey<Hooks::VehicleEvents> >(L);
     BGEventBindings          = new BindingMap< EventKey<Hooks::BGEvents> >(L);
+    TicketEventBindings      = new BindingMap< EventKey<Hooks::TicketEvents> >(L);
 
     PacketEventBindings      = new BindingMap< EntryKey<Hooks::PacketEvents> >(L);
     CreatureEventBindings    = new BindingMap< EntryKey<Hooks::CreatureEvents> >(L);
@@ -1105,6 +1107,15 @@ int Eluna::Register(lua_State* L, uint8 regtype, uint32 entry, ObjectGuid guid, 
                 auto key = EntryKey<Hooks::InstanceEvents>((Hooks::InstanceEvents)event_id, entry);
                 bindingID = InstanceEventBindings->Insert(key, functionRef, shots);
                 createCancelCallback(L, bindingID, InstanceEventBindings);
+                return 1; // Stack: callback
+            }
+            break;
+        case Hooks::REGTYPE_TICKET:
+            if (event_id < Hooks::TICKET_EVENT_COUNT)
+            {
+                auto key = EventKey<Hooks::TicketEvents>((Hooks::TicketEvents)event_id);
+                bindingID = TicketEventBindings->Insert(key, functionRef, shots);
+                createCancelCallback(L, bindingID, TicketEventBindings);
                 return 1; // Stack: callback
             }
             break;

--- a/src/LuaEngine/LuaEngine.h
+++ b/src/LuaEngine/LuaEngine.h
@@ -22,6 +22,7 @@
 #include "ElunaUtility.h"
 #include "HttpManager.h"
 #include "EventEmitter.h"
+#include "TicketMgr.h"
 #include <mutex>
 #include <memory>
 
@@ -216,6 +217,7 @@ public:
     BindingMap< EntryKey<Hooks::GossipEvents> >*     PlayerGossipBindings;
     BindingMap< EntryKey<Hooks::InstanceEvents> >*   MapEventBindings;
     BindingMap< EntryKey<Hooks::InstanceEvents> >*   InstanceEventBindings;
+    BindingMap< EventKey<Hooks::TicketEvents> >*     TicketEventBindings;
 
     BindingMap< UniqueObjectKey<Hooks::CreatureEvents> >*  CreatureUniqueBindings;
 
@@ -520,6 +522,13 @@ public:
     void OnBGEnd(BattleGround* bg, BattleGroundTypeId bgId, uint32 instanceId, TeamId winner);
     void OnBGCreate(BattleGround* bg, BattleGroundTypeId bgId, uint32 instanceId);
     void OnBGDestroy(BattleGround* bg, BattleGroundTypeId bgId, uint32 instanceId);
+
+    /* Ticket */
+    void OnTicketCreate(Player* player, GmTicket* ticket);
+    void OnTicketUpdate(Player* player, GmTicket* ticket);
+    void OnTicketClose(Player* player, GmTicket* ticket);
+    void OnTicketStatusUpdate(Player* player, GmTicket* ticket);
+    void OnTicketResolve(Player* player, GmTicket* ticket);
 };
 template<> Unit* Eluna::CHECKOBJ<Unit>(lua_State* L, int narg, bool error);
 template<> Object* Eluna::CHECKOBJ<Object>(lua_State* L, int narg, bool error);

--- a/src/LuaEngine/LuaFunctions.cpp
+++ b/src/LuaEngine/LuaFunctions.cpp
@@ -40,6 +40,7 @@ extern "C"
 #include "AchievementMethods.h"
 #include "ItemTemplateMethods.h"
 #include "RollMethods.h"
+#include "TicketMethods.h"
 
 luaL_Reg GlobalMethods[] =
 {
@@ -60,6 +61,7 @@ luaL_Reg GlobalMethods[] =
     { "RegisterBGEvent", &LuaGlobalFunctions::RegisterBGEvent },
     { "RegisterMapEvent", &LuaGlobalFunctions::RegisterMapEvent },
     { "RegisterInstanceEvent", &LuaGlobalFunctions::RegisterInstanceEvent },
+    { "RegisterTicketEvent", &LuaGlobalFunctions::RegisterTicketEvent },
 
     { "ClearBattleGroundEvents", &LuaGlobalFunctions::ClearBattleGroundEvents },
     { "ClearCreatureEvents", &LuaGlobalFunctions::ClearCreatureEvents },
@@ -77,6 +79,7 @@ luaL_Reg GlobalMethods[] =
     { "ClearServerEvents", &LuaGlobalFunctions::ClearServerEvents },
     { "ClearMapEvents", &LuaGlobalFunctions::ClearMapEvents },
     { "ClearInstanceEvents", &LuaGlobalFunctions::ClearInstanceEvents },
+    { "ClearTicketEvents", &LuaGlobalFunctions::ClearTicketEvents },
 
     // Getters
     { "GetLuaEngine", &LuaGlobalFunctions::GetLuaEngine },
@@ -1290,6 +1293,39 @@ ElunaRegister<Roll> RollMethods[] =
     { NULL, NULL }
 };
 
+ElunaRegister<GmTicket> TicketMethods[] =
+{
+    { "IsClosed", &LuaTicket::IsClosed },
+    { "IsCompleted", &LuaTicket::IsCompleted },
+    { "IsFromPlayer", &LuaTicket::IsFromPlayer },
+    { "IsAssigned", &LuaTicket::IsAssigned },
+    { "IsAssignedTo", &LuaTicket::IsAssignedTo },
+    { "IsAssignedNotTo", &LuaTicket::IsAssignedNotTo },
+
+    { "GetId", &LuaTicket::GetId },
+    { "GetPlayer", &LuaTicket::GetPlayer },
+    { "GetPlayerName", &LuaTicket::GetPlayerName },
+    { "GetMessage", &LuaTicket::GetMessage },
+    { "GetAssignedPlayer", &LuaTicket::GetAssignedPlayer },
+    { "GetAssignedToGUID", &LuaTicket::GetAssignedToGUID },
+    { "GetLastModifiedTime", &LuaTicket::GetLastModifiedTime },
+    { "GetResponse", &LuaTicket::GetResponse },
+    { "GetChatLog", &LuaTicket::GetChatLog },
+
+    { "SetAssignedTo", &LuaTicket::SetAssignedTo },
+    { "SetResolvedBy", &LuaTicket::SetResolvedBy },
+    { "SetCompleted", &LuaTicket::SetCompleted },
+    { "SetMessage", &LuaTicket::SetMessage },
+    { "SetComment", &LuaTicket::SetComment },
+    { "SetViewed", &LuaTicket::SetViewed },
+    { "SetUnassigned", &LuaTicket::SetUnassigned },
+    { "SetPosition", &LuaTicket::SetPosition },
+    { "AppendResponse", &LuaTicket::AppendResponse },
+    { "DeleteResponse", &LuaTicket::DeleteResponse },
+
+    { NULL, NULL }
+};
+
 // fix compile error about accessing vehicle destructor
 template<> int ElunaTemplate<Vehicle>::CollectGarbage(lua_State* L)
 {
@@ -1434,6 +1470,9 @@ void RegisterFunctions(Eluna* E)
 
     ElunaTemplate<Roll>::Register(E, "Roll");
     ElunaTemplate<Roll>::SetMethods(E, RollMethods);
+
+    ElunaTemplate<GmTicket>::Register(E, "Ticket");
+    ElunaTemplate<GmTicket>::SetMethods(E, TicketMethods);
 
     ElunaTemplate<long long>::Register(E, "long long", true);
 

--- a/src/LuaEngine/hooks/TicketHooks.cpp
+++ b/src/LuaEngine/hooks/TicketHooks.cpp
@@ -1,0 +1,71 @@
+/*
+ * Copyright (C) 2010 - 2016 Eluna Lua Engine <http://emudevs.com/>
+ * This program is free software licensed under GPL version 3
+ * Please see the included DOCS/LICENSE.md for more information
+ */
+
+#include "Hooks.h"
+#include "HookHelpers.h"
+#include "LuaEngine.h"
+#include "BindingMap.h"
+#include "ElunaIncludes.h"
+#include "ElunaTemplate.h"
+
+using namespace Hooks;
+
+#define START_HOOK(EVENT) \
+    if (!IsEnabled())\
+        return;\
+    auto key = EventKey<TicketEvents>(EVENT);\
+    if (!TicketEventBindings->HasBindingsFor(key))\
+        return;\
+    LOCK_ELUNA
+
+#define START_HOOK(EVENT) \
+    if (!IsEnabled())\
+        return;\
+    auto key = EventKey<TicketEvents>(EVENT);\
+    if (!TicketEventBindings->HasBindingsFor(key))\
+        return;\
+    LOCK_ELUNA
+
+void Eluna::OnTicketCreate(Player* player, GmTicket* ticket)
+{
+    START_HOOK(TICKET_EVENT_ON_CREATE);
+    Push(player);
+    Push(ticket);
+    CallAllFunctions(TicketEventBindings, key);
+}
+
+void Eluna::OnTicketUpdate(Player* player, GmTicket* ticket)
+{
+    START_HOOK(TICKET_EVENT_ON_UPDATE);
+    Push(player);
+    Push(ticket);
+    CallAllFunctions(TicketEventBindings, key);
+}
+
+void Eluna::OnTicketClose(Player* player, GmTicket* ticket)
+{
+    START_HOOK(TICKET_EVENT_ON_CLOSE);
+    Push(player);
+    Push(ticket);
+    CallAllFunctions(TicketEventBindings, key);
+}
+
+void Eluna::OnTicketStatusUpdate(Player* player, GmTicket* ticket)
+{
+    START_HOOK(TICKET_EVENT_STATUS_UPDATE);
+    Push(player);
+    Push(ticket);
+    CallAllFunctions(TicketEventBindings, key);
+}
+
+void Eluna::OnTicketResolve(Player* player, GmTicket* ticket)
+{
+    START_HOOK(TICKET_EVENT_ON_RESOLVE);
+    Push(player);
+    Push(ticket);
+    CallAllFunctions(TicketEventBindings, key);
+}
+

--- a/src/LuaEngine/methods/GlobalMethods.h
+++ b/src/LuaEngine/methods/GlobalMethods.h
@@ -1216,6 +1216,30 @@ namespace LuaGlobalFunctions
     }
 
     /**
+     * Registers a [Ticket] event handler.
+     *
+     * <pre>
+     * enum TicketEvents
+     * {
+     *     TICKET_EVENT_ON_CREATE                          = 1,    // (event, player, ticket)
+     *     TICKET_EVENT_ON_UPDATE                          = 2,    // (event, player, ticket, message)
+     *     TICKET_EVENT_ON_CLOSE                           = 3,    // (event, player, ticket)
+     *     TICKET_EVENT_STATUS_UPDATE                      = 4,    // (event, player, ticket)
+     *     TICKET_EVENT_ON_RESOLVE                         = 5,    // (event, player, ticket)
+     *     TICKET_EVENT_COUNT
+     * };
+     * </pre>
+     *
+     * @param uint32 event : event ID, refer to UnitEvents above
+     * @param function function : function to register
+     * @param uint32 shots = 0 : the number of times the function will be called, 0 means "always call this function"
+     */
+    int RegisterTicketEvent(lua_State* L)
+    {
+        return RegisterEventHelper(L, Hooks::REGTYPE_TICKET);
+    }
+
+    /**
      * Reloads the Lua engine.
      */
     int ReloadEluna(lua_State* /*L*/)
@@ -3090,6 +3114,33 @@ namespace LuaGlobalFunctions
             Eluna::GetEluna(L)->InstanceEventBindings->Clear(Key((Hooks::InstanceEvents)event_type, entry));
         }
 
+        return 0;
+    }
+
+    /**
+     * Unbinds event handlers for either all [Ticket] events, or one type of [Ticket] event.
+     *
+     * If `event_type` is `nil`, all [Ticket] event handlers are cleared.
+     *
+     * Otherwise, only event handlers for `event_type` are cleared.
+     *
+     * @proto ()
+     * @proto (event_type)
+     * @param uint32 event_type : the event whose handlers will be cleared, see [Global:RegisterTicketEvent]
+     */
+    int ClearTicketEvents(lua_State* L)
+    {
+        typedef EventKey<Hooks::TicketEvents> Key;
+
+        if (lua_isnoneornil(L, 1))
+        {
+            Eluna::GetEluna(L)->TicketEventBindings->Clear();
+        }
+        else
+        {
+            uint32 event_type = Eluna::CHECKVAL<uint32>(L, 1);
+            Eluna::GetEluna(L)->TicketEventBindings->Clear(Key((Hooks::TicketEvents)event_type));
+        }
         return 0;
     }
 

--- a/src/LuaEngine/methods/TicketMethods.h
+++ b/src/LuaEngine/methods/TicketMethods.h
@@ -1,0 +1,323 @@
+/*
+* Copyright (C) 2010 - 2016 Eluna Lua Engine <http://emudevs.com/>
+* This program is free software licensed under GPL version 3
+* Please see the included DOCS/LICENSE.md for more information
+*/
+
+#ifndef TICKETMETHODS_H
+#define TICKETMETHODS_H
+
+/***
+ * An instance of a spell, created when the spell is cast by a [Unit].
+ *
+ * Inherits all methods from: none
+ */
+namespace LuaTicket
+{
+    /**
+     * Returns true if the [Ticket] is closed or false.
+     *
+     * @return bool is_closed
+     */
+    int IsClosed(lua_State* L, GmTicket* ticket)
+    {
+        Eluna::Push(L, ticket->IsClosed());
+        return 1;
+    }
+
+    /**
+     * Returns true if the [Ticket] is completed or false.
+     *
+     * @return bool is_completed
+     */
+    int IsCompleted(lua_State* L, GmTicket* ticket)
+    {
+        Eluna::Push(L, ticket->IsCompleted());
+        return 1;
+    }
+
+    /**
+     * Return true if this GUID is the same as the [Player] who created the [Ticket] or false.
+     *
+     * @param guid playerGuid : desired playerGuid
+     *
+     * @return bool same_guid
+     */
+    int IsFromPlayer(lua_State* L, GmTicket* ticket)
+    {
+        ObjectGuid guid = Eluna::CHECKVAL<ObjectGuid>(L, 2);
+
+        Eluna::Push(L, ticket->IsFromPlayer(guid));
+        return 1;
+    }
+
+    /**
+     * Return true if the [Ticket] is assigned or false.
+     *
+     * @return bool is_assigned
+     */
+    int IsAssigned(lua_State* L, GmTicket* ticket)
+    {
+        Eluna::Push(L, ticket->IsAssigned());
+        return 1;
+    }
+
+    /**
+     * Return true if the [Ticket] is assigned to the GUID or false.
+     *
+     * @param guid playerGuid : desired playerGuid
+     *
+     * @return bool is_assigned_to
+     */
+    int IsAssignedTo(lua_State* L, GmTicket* ticket)
+    {
+        ObjectGuid guid = Eluna::CHECKVAL<ObjectGuid>(L, 2);
+
+        Eluna::Push(L, ticket->IsAssignedTo(guid));
+        return 1;
+    }
+
+    /**
+     * Return true if the [Ticket] is not assigned to the GUID or false.
+     *
+     * @param guid playerGuid : desired playerGuid
+     *
+     * @return bool is_assigned_not_to
+     */
+    int IsAssignedNotTo(lua_State* L, GmTicket* ticket)
+    {
+        ObjectGuid guid = Eluna::CHECKVAL<ObjectGuid>(L, 2);
+
+        Eluna::Push(L, ticket->IsAssignedNotTo(guid));
+        return 1;
+    }
+
+    /**
+     * Return the [Ticket] id.
+     *
+     * @return unint32 ticket_id
+     */
+    int GetId(lua_State* L, GmTicket* ticket)
+    {
+        Eluna::Push(L, ticket->GetId());
+        return 1;
+    }
+
+    /**
+     * Return the [Player] from the [Ticket].
+     *
+     * @return [Player] player
+     */
+    int GetPlayer(lua_State* L, GmTicket* ticket)
+    {
+        Eluna::Push(L, ticket->GetPlayer());
+        return 1;
+    }
+
+    /**
+     * Return the [Player] name from the [Ticket].
+     *
+     * @return string player_name
+     */
+    int GetPlayerName(lua_State* L, GmTicket* ticket)
+    {
+        Eluna::Push(L, ticket->GetPlayerName());
+        return 1;
+    }
+
+    /**
+     * Returns the message sent in the [Ticket].
+     *
+     * @return string message
+     */
+    int GetMessage(lua_State* L, GmTicket* ticket)
+    {
+        Eluna::Push(L, ticket->GetMessage());
+        return 1;
+    }
+
+    /**
+     * Returns the assigned [Player].
+     *
+     * @return [Player] assigned_player
+     */
+    int GetAssignedPlayer(lua_State* L, GmTicket* ticket)
+    {
+        Eluna::Push(L, ticket->GetAssignedPlayer());
+        return 1;
+    }
+
+    /**
+     * Returns the assigned guid.
+     *
+     * @return [ObjectGUID] assigned_guid
+     */
+    int GetAssignedToGUID(lua_State* L, GmTicket* ticket)
+    {
+        Eluna::Push(L, ticket->GetAssignedToGUID());
+        return 1;
+    }
+
+    /**
+     * Returns the last modified time from the [Ticket].
+     *
+     * @return uint64 last_modified
+     */
+    int GetLastModifiedTime(lua_State* L, GmTicket* ticket)
+    {
+        Eluna::Push(L, ticket->GetLastModifiedTime());
+        return 1;
+    }
+
+    /**
+     * Assign the [Ticket] to a player via his GUID.
+     *
+     * @param guid playerGuid : desired playerGuid
+     * @param bool isAdmin : true if the guid is an Admin or false (default false)
+     */
+    int SetAssignedTo(lua_State* L, GmTicket* ticket)
+    {
+        ObjectGuid guid = Eluna::CHECKVAL<ObjectGuid>(L, 2);
+        bool is_admin = Eluna::CHECKVAL<bool>(L, 2, false);
+        ticket->SetAssignedTo(guid, is_admin);
+        return 0;
+    }
+
+    /**
+     * Set [Ticket] resolved by player via his GUID.
+     *
+     * @param guid playerGuid : desired playerGuid
+     */
+    int SetResolvedBy(lua_State* L, GmTicket* ticket)
+    {
+        ObjectGuid guid = Eluna::CHECKVAL<ObjectGuid>(L, 2);
+        ticket->SetResolvedBy(guid);
+        return 0;
+    }
+
+    /**
+     * Set [Ticket] completed.
+     *
+     */
+    int SetCompleted(lua_State* /*L*/, GmTicket* ticket)
+    {
+        ticket->SetCompleted();
+        return 0;
+    }
+
+    /**
+     * Set [Ticket] message.
+     *
+     * @param string message: desired message
+     *
+     */
+    int SetMessage(lua_State* L, GmTicket* ticket)
+    {
+        std::string message = Eluna::CHECKVAL<std::string>(L, 2);
+
+        ticket->SetMessage(message);
+        return 0;
+    }
+
+    /**
+     * Set [Ticket] comment.
+     *
+     * @param string comment: desired comment
+     *
+     */
+    int SetComment(lua_State* L, GmTicket* ticket)
+    {
+        std::string comment = Eluna::CHECKVAL<std::string>(L, 2);
+
+        ticket->SetComment(comment);
+        return 0;
+    }
+
+    /**
+     * Set [Ticket] is viewed.
+     *
+     */
+    int SetViewed(lua_State* /*L*/, GmTicket* ticket)
+    {
+        ticket->SetViewed();
+        return 0;
+    }
+
+    /**
+     * Set [Ticket] is unassigned.
+     *
+     */
+    int SetUnassigned(lua_State* /*L*/, GmTicket* ticket)
+    {
+        ticket->SetUnassigned();
+        return 0;
+    }
+
+    /**
+     * Set the new [Ticket] creation position.
+     *
+     * @param uint32 mapId
+     * @param float x
+     * @param float y
+     * @param float z
+     *
+     */
+    int SetPosition(lua_State* L, GmTicket* ticket)
+    {
+        uint32 mapId = Eluna::CHECKVAL<uint32>(L, 2);
+        float x = Eluna::CHECKVAL<float>(L, 2);
+        float y = Eluna::CHECKVAL<float>(L, 2);
+        float z = Eluna::CHECKVAL<float>(L, 2);
+
+        ticket->SetPosition(mapId, x, y, z);
+        return 0;
+    }
+
+    /**
+     * Adds a response to the [Ticket].
+     *
+     * @param string response: desired response
+     *
+     */
+    int AppendResponse(lua_State* L, GmTicket* ticket)
+    {
+        std::string response = Eluna::CHECKVAL<std::string>(L, 2);
+
+        ticket->AppendResponse(response);
+        return 0;
+    }
+
+    /**
+     * Return the [Ticket] response.
+     *
+     * @return string response
+     */
+    int GetResponse(lua_State* L, GmTicket* ticket)
+    {
+        Eluna::Push(L, ticket->GetResponse());
+        return 1;
+    }
+
+    /**
+     * Delete the [Ticket] response.
+     *
+     */
+    int DeleteResponse(lua_State* /*L*/, GmTicket* ticket)
+    {
+        ticket->DeleteResponse();
+        return 0;
+    }
+
+    /**
+     * Return the [Ticket] chatlog.
+     *
+     * @return string chatlog
+     */
+    int GetChatLog(lua_State* L, GmTicket* ticket)
+    {
+        Eluna::Push(L, ticket->GetChatLog());
+        return 1;
+    }
+};
+#endif
+


### PR DESCRIPTION
This PRintroduces a new hook system for ticket events in Eluna, allowing developers to handle ticket-related actions dynamically. Additionally, new methods have been added to the `Ticket` object.

### Requirement
AC PR : https://github.com/azerothcore/azerothcore-wotlk/pull/21238

### Supported Ticket Events  
1. **`TICKET_EVENT_ON_CREATE`**  
   Triggered when a ticket is created.  
   **Signature**: `(event, player, ticket)`

2. **`TICKET_EVENT_ON_UPDATE`**  
   Triggered when a ticket is updated.  
   **Signature**: `(event, player, ticket)`

3. **`TICKET_EVENT_ON_CLOSE`**  
   Triggered when a ticket is closed.  
   **Signature**: `(event, player, ticket)`

4. **`TICKET_EVENT_STATUS_UPDATE`**  
   Triggered when the ticket's status is updated.  
   **Signature**: `(event, player, ticket)`

5. **`TICKET_EVENT_ON_RESOLVE`**  
   Triggered when a ticket is resolved.  
   **Signature**: `(event, player, ticket)`

### Example Usage  
```lua
local function OnTicketCreate(event, player, ticket)
    print("Test: OnTicketCreate triggered:", ticket:GetId())
end
RegisterTicketEvent(TICKET_EVENT_ON_CREATE, OnTicketCreate)
```

## Test performed :
```lua
TICKET_EVENT_ON_CREATE                          = 1
TICKET_EVENT_ON_UPDATE                          = 2
TICKET_EVENT_ON_CLOSE                           = 3
TICKET_EVENT_STATUS_UPDATE                      = 4
TICKET_EVENT_ON_RESOLVE                         = 5

local function OnTicketCreate(event, player, ticket)
    print("Test: OnTicketCreate triggered:", ticket:GetId())
end
RegisterTicketEvent(TICKET_EVENT_ON_CREATE, OnTicketCreate)

local function OnTicketUpdate(event, player, ticket)
    print("Test: OnTicketUpdate triggered:", ticket:GetId(), "Message:", ticket:GetMessage())
end
RegisterTicketEvent(TICKET_EVENT_ON_UPDATE, OnTicketUpdate)

local function OnTicketClose(event, player, ticket)
    print("Test: OnTicketClose triggered:", ticket:IsClosed())
end
RegisterTicketEvent(TICKET_EVENT_ON_CLOSE, OnTicketClose)

local function OnTicketStatusUpdate(event, player, ticket)
    print("Test: OnTicketClose triggered:", ticket:GetId())
end
RegisterTicketEvent(TICKET_EVENT_STATUS_UPDATE, OnTicketStatusUpdate)

local function OnTicketResolve(event, player, ticket)
    print("Test: OnTicketClose triggered:", ticket:IsCompleted())
end
RegisterTicketEvent(TICKET_EVENT_ON_RESOLVE, OnTicketResolve)
```

**Results:**
![image](https://github.com/user-attachments/assets/bbd5d8e7-832e-4ec8-a48c-ab2947fa8a44)

https://github.com/user-attachments/assets/6f1b2c79-ccf8-4e56-b5db-2ca42dd0c3c9

