### PR TITLE
Feat(LuaEngine/MapMethods): Add GetCreatures and GetCreaturesByAreaId methods

### DIFF
--- a/src/LuaEngine/LuaFunctions.cpp
+++ b/src/LuaEngine/LuaFunctions.cpp
@@ -1184,6 +1184,9 @@ ElunaRegister<Map> MapMethods[] =
     { "GetAreaId", &LuaMap::GetAreaId },
     { "GetHeight", &LuaMap::GetHeight },
     { "GetWorldObject", &LuaMap::GetWorldObject },
+    { "GetCreatures", &LuaMap::GetCreatures },
+    { "GetCreaturesByAreaId", &LuaMap::GetCreaturesByAreaId },
+
 
     // Setters
     { "SetWeather", &LuaMap::SetWeather },

--- a/src/LuaEngine/methods/MapMethods.h
+++ b/src/LuaEngine/methods/MapMethods.h
@@ -325,5 +325,62 @@ namespace LuaMap
         lua_settop(L, tbl);
         return 1;
     }
+
+    /**
+     * Returns a table with all the current [Creature]s in the map
+     * 
+     * @return table mapCreatures
+     */
+    int GetCreatures(lua_State* L, Map* map)
+    {
+        const auto& creatures = map->GetCreatureBySpawnIdStore();
+
+        lua_createtable(L, creatures.size(), 0);
+        int tbl = lua_gettop(L);
+
+        for (const auto& pair : creatures)
+        {
+            Creature* creature = pair.second;
+
+            Eluna::Push(L, creature);
+            lua_rawseti(L, tbl, creature->GetSpawnId());
+        }
+
+        lua_settop(L, tbl);
+        return 1;
+    }
+
+    /**
+     * Returns a table with all the current [Creature]s in the specific area id
+     * 
+     * @param number areaId : specific area id
+     * @return table mapCreatures
+     */
+    int GetCreaturesByAreaId(lua_State* L, Map* map)
+    {
+        uint32 areaId = Eluna::CHECKVAL<uint32>(L, 2, -1);
+        std::vector<Creature*> filteredCreatures;
+
+        for (const auto& pair : map->GetCreatureBySpawnIdStore())
+        {
+            Creature* creature = pair.second;
+            if (areaId == -1 || creature->GetAreaId() == areaId)
+            {
+                filteredCreatures.push_back(creature);
+            }
+        }
+
+        lua_createtable(L, filteredCreatures.size(), 0);
+        int tbl = lua_gettop(L);
+
+        for (Creature* creature : filteredCreatures)
+        {
+            Eluna::Push(L, creature);
+            lua_rawseti(L, tbl, creature->GetSpawnId());
+        }
+
+        lua_settop(L, tbl);
+        return 1;
+    }
 };
 #endif


### PR DESCRIPTION
This pull request introduces two new methods to the `Map` class in mod-Eluna, enabling developers to retrieve lists of creatures currently present on a map or within a specific area of a map

## New Methods

### 1. `GetCreatures`
- **GetCreatures**: Returns a Lua table containing all the current `Creature` objects on the map, 

### 2. `GetCreaturesByAreaId`
- **GetCreaturesByAreaId**: Returns a Lua table containing all the `Creature` objects within a specific area ID on the map, indexed by their spawn IDs.

## Code Highlights

### Example: Retrieving All Creatures on a Map
```lua
local map_creatures = player:GetMap():GetCreatures()

for spawn_id, creature in pairs(map_creatures) do
  print("Map Creatures",spawn_id, creature)
end
```

### Example: Retrieving Creatures by Area ID (for map 0)
```lua
local map_area_creatures= player:GetMap():GetCreaturesByAreaId(9) -- Northshire Valley

for spawn_id, creature in pairs(map_area_creatures) do
  print("Map Area Creatures",spawn_id, creature)
end
```

## Test performed :
```lua
local function OnPlayerLogin(event, player)
    local map_creatures = player:GetMap():GetCreatures()

    for spawn_id, creature in pairs(map_creatures) do
        print("Map Creatures", spawn_id, creature)
    end

    local map_area_creatures = player:GetMap():GetCreaturesByAreaId(9)

    for spawn_id, creature in pairs(map_area_creatures) do
        print("Map Area Creatures", spawn_id, creature)
    end
end
RegisterPlayerEvent(3, OnPlayerLogin)
```
**Results:**
![image](https://github.com/user-attachments/assets/d4e03bc5-20cf-49aa-9294-2d511abb7368)

https://github.com/user-attachments/assets/8457829b-28a5-49a9-89ba-361a7dcf24cf