### PR TITLE
Feat(LuaEngine/PlayerMethods): Add GetHomebind, GetSpells and TeleportTo

### DIFF
--- a/src/LuaEngine/LuaFunctions.cpp
+++ b/src/LuaEngine/LuaFunctions.cpp
@@ -560,6 +560,8 @@ ElunaRegister<Player> PlayerMethods[] =
     { "SetPlayerLock", &LuaPlayer::SetPlayerLock },
     { "SetGender", &LuaPlayer::SetGender },
     { "SetSheath", &LuaPlayer::SetSheath },
+    { "GetHomebind", &LuaPlayer::GetHomebind },
+    { "GetSpells", &LuaPlayer::GetSpells },
 
     // Boolean
     { "HasTankSpec", &LuaPlayer::HasTankSpec },
@@ -730,6 +732,7 @@ ElunaRegister<Player> PlayerMethods[] =
     { "SendCinematicStart", &LuaPlayer::SendCinematicStart },
     { "SendMovieStart", &LuaPlayer::SendMovieStart },
     { "UpdatePlayerSetting", &LuaPlayer::UpdatePlayerSetting },
+    { "TeleportTo", &LuaPlayer::TeleportTo },
 
     { NULL, NULL }
 };

--- a/src/LuaEngine/methods/PlayerMethods.h
+++ b/src/LuaEngine/methods/PlayerMethods.h
@@ -3988,3 +3988,4 @@ namespace LuaPlayer
     }
 };
 #endif
+

--- a/src/LuaEngine/methods/PlayerMethods.h
+++ b/src/LuaEngine/methods/PlayerMethods.h
@@ -3913,5 +3913,78 @@ namespace LuaPlayer
     player->RemovePet(player->GetPet(), (PetSaveMode)mode, returnreagent);
     return 0;
     }*/
+
+    /**
+     *  Returns the [Player] spells list
+     *
+     * @return table playerSpells
+     */
+    int GetSpells(lua_State* L, Player* player)
+    {
+        std::list<uint32> list;
+        lua_createtable(L, list.size(), 0);
+        int tbl = lua_gettop(L);
+        uint32 i = 0;
+
+        PlayerSpellMap spellMap = player->GetSpellMap();
+        for (PlayerSpellMap::const_iterator itr = spellMap.begin(); itr != spellMap.end(); ++itr)
+        {
+            SpellInfo const* spellInfo = sSpellMgr->AssertSpellInfo(itr->first);
+            Eluna::Push(L, spellInfo->Id);
+            lua_rawseti(L, tbl, ++i);
+        }
+
+        lua_settop(L, tbl);
+        return 1;
+    }
+
+    /**
+     *  Returns the [Player] homebind location.
+     *
+     *  @return table homebind : a table containing the player's homebind information:
+     *      - uint32 mapId: The ID of the map where the player is bound.
+     *      - float x: The X coordinate of the homebind location.
+     *      - float y: The Y coordinate of the homebind location.
+     *      - float z: The Z coordinate of the homebind location.
+     */
+    int GetHomebind(lua_State* L, Player* player)
+    {
+        lua_newtable(L);
+        lua_pushinteger(L, player->m_homebindMapId);
+        lua_setfield(L, -2, "mapId");
+
+        lua_pushnumber(L, player->m_homebindX);
+        lua_setfield(L, -2, "x");
+
+        lua_pushnumber(L, player->m_homebindY);
+        lua_setfield(L, -2, "y");
+
+        lua_pushnumber(L, player->m_homebindZ);
+        lua_setfield(L, -2, "z");
+
+        return 1;
+    }
+
+    /**
+     *  Teleports [Player] to a predefined location based on the teleport name.
+     *
+     *  @param string tele : The name of the predefined teleport location.
+     */
+    int TeleportTo(lua_State* L, Player* player)
+    {
+        std::string tele = Eluna::CHECKVAL<std::string>(L, 2);
+        const GameTele* game_tele = sObjectMgr->GetGameTele(tele);
+
+        MapEntry const* map = sMapStore.LookupEntry(game_tele->mapId);
+
+        if (player->IsInFlight())
+        {
+            player->GetMotionMaster()->MovementExpired();
+            player->m_taxi.ClearTaxiDestinations();
+        }
+
+        player->TeleportTo(game_tele->mapId, game_tele->position_x, game_tele->position_y, game_tele->position_z, game_tele->orientation);
+        return 0;
+    }
 };
 #endif


### PR DESCRIPTION
This pull request introduces 3 new methods to the `Player` class in mod-Eluna, enabling developers to retrieve all player learned spell, teleport player with teleport name or get player homebind.

## New Methods

1. **`GetSpells`**: Retrieve a list of all spells known by a player.
2. **`GetHomebind`**: Access the player’s homebind location.
3. **`TeleportTo`**: Teleport a player to a predefined location (game_tele table).

## Code Highlights

### Example: Get All Player Learned Spells
```lua
local spells = player:GetSpells()

for _, spell_id in pairs(spells) do
  print("Learned Spell", spell_id)
end
```

### Example: Retrieving Player Homebind position
```lua
local player_homebind = player:GetHomebind()
print("Player Homebind", player_homebind.mapId , player_homebind.x, player_homebind.y, player_homebind.z)
```

### Example: Teleport Player To Specific GameTele
```lua
player:TeleportTo("Stormwind")
```

## Test performed :
```lua
local function OnPlayerLogin(event, player)
    local spells = player:GetSpells()

    for _, spell_id in pairs(spells) do
      print("Learned Spell", spell_id)
    end

    local player_homebind = player:GetHomebind()
    print("Player Homebind", player_homebind.mapId , player_homebind.x, player_homebind.y, player_homebind.z)

    player:TeleportTo("Stormwind")
end
RegisterPlayerEvent(3, OnPlayerLogin)
```
**Results:**
![image](https://github.com/user-attachments/assets/5d42f002-3872-43be-94f4-52eab4bad40f)

https://github.com/user-attachments/assets/11e05fab-eec9-4c1c-b96b-0d533e26bba4

