### PR TITLE
feat(LuaEngine/GlobalMethods): add GetGossipMenuOptionLocale, GetMapEntrance

### DIFF
--- a/src/LuaEngine/LuaFunctions.cpp
+++ b/src/LuaEngine/LuaFunctions.cpp
@@ -121,6 +121,8 @@ luaL_Reg GlobalMethods[] =
     { "PrintError", &LuaGlobalFunctions::PrintError },
     { "PrintDebug", &LuaGlobalFunctions::PrintDebug },
     { "GetActiveGameEvents", &LuaGlobalFunctions::GetActiveGameEvents },
+    { "GetGossipMenuOptionLocale", &LuaGlobalFunctions::GetGossipMenuOptionLocale },
+    { "GetMapEntrance", &LuaGlobalFunctions::GetMapEntrance },
 
     // Boolean
     { "IsCompatibilityMode", &LuaGlobalFunctions::IsCompatibilityMode },

--- a/src/LuaEngine/methods/GlobalMethods.h
+++ b/src/LuaEngine/methods/GlobalMethods.h
@@ -3200,5 +3200,84 @@ namespace LuaGlobalFunctions
 
         return 0;
     }
+
+    /**
+     * Gets the localized OptionText and BoxText for a specific gossip menu option.
+     * If the text for the specified locale is not found, it returns the default text.
+     *
+     * @param uint32 menuId : The ID of the gossip menu.
+     * @param uint32 optionId : The ID of the gossip menu option.
+     * @param uint8 locale : The locale to retrieve the text for. 0 represents the default locale.
+     *
+     * @return string, string : The localized OptionText and BoxText for the gossip menu option, or the default text if no localization is found.
+     */
+    int GetGossipMenuOptionLocale(lua_State* L)
+    {
+        uint32 menuId = Eluna::CHECKVAL<uint32>(L, 1);
+        uint32 optionId = Eluna::CHECKVAL<uint32>(L, 2);
+        uint8 locale = Eluna::CHECKVAL<uint8>(L, 3);
+
+        std::string strOptionText;
+        std::string strBoxText;
+
+        if (locale != DEFAULT_LOCALE)
+        {
+            if (GossipMenuItemsLocale const* gossipMenuLocale = sObjectMgr->GetGossipMenuItemsLocale(MAKE_PAIR32(menuId, optionId)))
+            {
+                ObjectMgr::GetLocaleString(gossipMenuLocale->OptionText, LocaleConstant(locale), strOptionText);
+                ObjectMgr::GetLocaleString(gossipMenuLocale->BoxText, LocaleConstant(locale), strBoxText);
+            }
+        }
+
+        if (strOptionText.empty() || strBoxText.empty())
+        {
+            GossipMenuItemsMapBounds bounds = sObjectMgr->GetGossipMenuItemsMapBounds(menuId);
+            for (auto itr = bounds.first; itr != bounds.second; ++itr)
+            {
+                if (itr->second.OptionID == optionId)
+                {
+                    if (strOptionText.empty())
+                        strOptionText = itr->second.OptionText;
+                    if (strBoxText.empty())
+                        strBoxText = itr->second.BoxText;
+                    break;
+                }
+            }
+        }
+
+        Eluna::Push(L, strOptionText);
+        Eluna::Push(L, strBoxText);
+        return 2; // 2 values returned to Lua
+    }
+
+    /**
+     * Return the entrance position (x, y, z, o) of the specified dungeon map id
+     *
+     * @param uint32 mapId
+     *
+     * return uint32 pos_x
+     * return uint32 pos_y
+     * return uint32 pos_z
+     * return uint32 pos_o
+     * 
+     */
+    int GetMapEntrance(lua_State* L)
+    {
+        uint32 mapId = Eluna::CHECKVAL<uint32>(L, 1);
+        AreaTriggerTeleport const* at = sObjectMgr->GetMapEntranceTrigger(mapId);
+
+        if (!at)
+        {
+            lua_pushnil(L);
+            return 1;
+        }
+
+        Eluna::Push(L, at->target_X);
+        Eluna::Push(L, at->target_Y);
+        Eluna::Push(L, at->target_Z);
+        Eluna::Push(L, at->target_Orientation);
+
+        return 5;
+    }
 }
 #endif

--- a/src/LuaEngine/methods/GlobalMethods.h
+++ b/src/LuaEngine/methods/GlobalMethods.h
@@ -3276,7 +3276,7 @@ namespace LuaGlobalFunctions
 
         Eluna::Push(L, strOptionText);
         Eluna::Push(L, strBoxText);
-        return 2; // 2 values returned to Lua
+        return 2;
     }
 
     /**

--- a/src/LuaEngine/methods/GlobalMethods.h
+++ b/src/LuaEngine/methods/GlobalMethods.h
@@ -3307,6 +3307,7 @@ namespace LuaGlobalFunctions
         Eluna::Push(L, at->target_Orientation);
 
         return 5;
+    }
       
     /**  
      * Returns the instance of the specified DBC (DatabaseClient) store.


### PR DESCRIPTION
This pull request introduces 2 new methods in mod-Eluna, enabling developers to retrieve specific localized gossip_menu option and box_text, get map entrance position.

## New Methods

1. **`GetMapEntrance`**: Returns the entrance position (`x`, `y`, `z`, `o`) for a specified map ID.
2. **`GetGossipMenuOptionLocale`**: Retrieves the localized `OptionText` and `BoxText` for a specific gossip menu option. Falls back to the default text if the specified locale is unavailable.

## Code Highlights

### Example: Get Localized Gossip Text
```lua
local optionText, boxText = GetGossipMenuOptionLocale(1, 2, 3)
print(optionText, boxText)
```

### Example: Retrieving Map Entrance position
```lua
local x, y, z, o = GetMapEntrance(571)
print(x, y, z, o)
```

## Test performed :
```lua
local function OnPlayerLogin(event, player)
    local optionText, boxText = GetGossipMenuOptionLocale(10084, 0, 0)
    print("Option Menu Locale", optionText, boxText)

    optionText, boxText = GetGossipMenuOptionLocale(10084, 0, 2)
    print("Option Menu Locale", optionText, boxText)

    local x, y, z, o = GetMapEntrance(615)
    print("Map Entrance Position", x, y, z, o)

    player:Teleport(615, x, y, z, o)
end
RegisterPlayerEvent(3, OnPlayerLogin)
```
**Results:**
![image](https://github.com/user-attachments/assets/45f604bd-5ac1-4160-aea4-ea7ceb3d1b1a)

https://github.com/user-attachments/assets/bcb9b057-fb4d-41ac-95d7-b183b80c0798