### PR TITLE
Feat(LuaEngine/UnitMethods): Add GetThreat, ClearThreat, ResetAllThreat methods

### DIFF
--- a/src/LuaEngine/LuaFunctions.cpp
+++ b/src/LuaEngine/LuaFunctions.cpp
@@ -314,6 +314,7 @@ ElunaRegister<Unit> UnitMethods[] =
     // {"GetVehicle", &LuaUnit::GetVehicle},                           // :GetVehicle() - UNDOCUMENTED - Gets the Vehicle kit of the vehicle the unit is on
     { "GetMovementType", &LuaUnit::GetMovementType },
     { "GetAttackers", &LuaUnit::GetAttackers },
+    { "GetThreat", &LuaUnit::GetThreat },
 
     // Setters
     { "SetFaction", &LuaUnit::SetFaction },
@@ -447,6 +448,8 @@ ElunaRegister<Unit> UnitMethods[] =
     { "DealHeal", &LuaUnit::DealHeal },
     { "AddThreat", &LuaUnit::AddThreat },
     { "ModifyThreatPct", &LuaUnit::ModifyThreatPct },
+    { "ClearThreat", &LuaUnit::ClearThreat },
+    { "ResetAllThreat", &LuaUnit::ResetAllThreat },
 
     { NULL, NULL }
 };

--- a/src/LuaEngine/methods/UnitMethods.h
+++ b/src/LuaEngine/methods/UnitMethods.h
@@ -2714,5 +2714,41 @@ namespace LuaUnit
     Eluna::Push(L, summon);
     return 1;
     }*/
+
+    /**
+     * Clear the threat of a [Unit] in the threat list.
+     *
+     * @param [Unit] target
+     */
+    int ClearThreat(lua_State* L, Unit* unit)
+    {
+        Unit* target = Eluna::CHECKOBJ<Unit>(L, 2);
+
+        unit->GetThreatMgr().ClearThreat(target);
+        return 0;
+    }
+
+    /**
+     * Resets the [Unit]'s threat list, setting all threat targets' threat to 0.
+     */
+    int ResetAllThreat(lua_State* /*L*/, Unit* unit)
+    {
+        unit->GetThreatMgr().ResetAllThreat();
+        return 0;
+    }
+
+    /**
+     * Returns the threat of a [Unit].
+     *
+     * @param [Unit] target
+     * @return float threat
+     */
+    int GetThreat(lua_State* L, Unit* unit)
+    {
+        Unit* target = Eluna::CHECKOBJ<Unit>(L, 2);
+
+        Eluna::Push(L, unit->GetThreatMgr().GetThreat(target));
+        return 1;
+    }
 };
 #endif


### PR DESCRIPTION
This pull request introduces new methods to manage threat levels for units.

## New Methods

1. **`ClearThreat`**: Clears the threat of a specific target from a unit's threat list.
#### Example:
```lua
unit:ClearThreat(target)
```
2. **`ResetAllThreat`**: Resets all threat levels in the unit’s threat list to zero.
#### Example:
```lua
unit:ResetAllThreat()
```
3. **`GetThreat`**: Retrieves the current threat level of a specific target from a unit’s threat list.
#### Example:
```lua
local threat = unit:GetThreat(target)
print(threat)
```