### PR TITLE
Feat(LuaEngine/PlayerHooks): Add OnCanPlayerResurrect

### DIFF
--- a/src/ElunaLuaEngine_SC.cpp
+++ b/src/ElunaLuaEngine_SC.cpp
@@ -812,6 +812,11 @@ public:
     {
         sEluna->OnCreatureKilledByPet(player, killed);
     }
+
+    bool CanPlayerResurrect(Player* player) override
+    {
+        return sEluna->CanPlayerResurrect(player);
+    }
 };
 
 class Eluna_ServerScript : public ServerScript

--- a/src/LuaEngine/Hooks.h
+++ b/src/LuaEngine/Hooks.h
@@ -221,6 +221,7 @@ namespace Hooks
         PLAYER_EVENT_ON_GROUP_ROLL_REWARD_ITEM  =     56,       // (event, player, item, count, voteType, roll)
         PLAYER_EVENT_ON_BG_DESERTION            =     57,       // (event, player, type)
         PLAYER_EVENT_ON_PET_KILL                =     58,       // (event, player, killer)
+        PLAYER_EVENT_ON_CAN_RESURRECT           =     59,       // (event, player)
 
         PLAYER_EVENT_COUNT
     };

--- a/src/LuaEngine/LuaEngine.h
+++ b/src/LuaEngine/LuaEngine.h
@@ -447,6 +447,7 @@ public:
     void OnGroupRollRewardItem(Player* player, Item* item, uint32 count, RollVote voteType, Roll* roll);
     void OnBattlegroundDesertion(Player* player, const BattlegroundDesertionType type);
     void OnCreatureKilledByPet(Player* player, Creature* killed);
+    bool CanPlayerResurrect(Player* player);
 
     /* Vehicle */
     void OnInstall(Vehicle* vehicle);

--- a/src/LuaEngine/hooks/PlayerHooks.cpp
+++ b/src/LuaEngine/hooks/PlayerHooks.cpp
@@ -706,3 +706,11 @@ void Eluna::OnCreatureKilledByPet(Player* player, Creature* killed)
     Push(killed);
     CallAllFunctions(PlayerEventBindings, key);
 }
+
+bool Eluna::CanPlayerResurrect(Player* player)
+{
+    START_HOOK_WITH_RETVAL(PLAYER_EVENT_ON_CAN_RESURRECT, true);
+    Push(player);
+    return CallAllFunctionsBool(PlayerEventBindings, key);
+}
+

--- a/src/LuaEngine/methods/GlobalMethods.h
+++ b/src/LuaEngine/methods/GlobalMethods.h
@@ -716,6 +716,8 @@ namespace LuaGlobalFunctions
      *     PLAYER_EVENT_ON_CAN_GROUP_INVITE        =     55,       // (event, player, memberName) - Can return false to prevent inviting
      *     PLAYER_EVENT_ON_GROUP_ROLL_REWARD_ITEM  =     56,       // (event, player, item, count, voteType, roll)
      *     PLAYER_EVENT_ON_BG_DESERTION            =     57,       // (event, player, type)
+     *     PLAYER_EVENT_ON_PET_KILL                =     58,       // (event, player, killer)
+     *     PLAYER_EVENT_ON_CAN_RESURRECT           =     59,       // (event, player)
      * };
      * </pre>
      *


### PR DESCRIPTION
## 📝 Description

This pull request introduces a new Hook in `mod-eluna` for `player`:

- `PLAYER_EVENT_ON_CAN_RESURRECT`

## 🚨 Prerequisites

> [!WARNING]
> Requires the following dependency:
> - [AzerothCore PR #21272](https://github.com/azerothcore/azerothcore-wotlk/pull/21272)


## 🆕 New Hooks Overview

#### Example
```lua
local function OnCanPlayerResurrect(event, player)
    return false
end
RegisterPlayerEvent(59, OnCanPlayerResurrect)
```

## 🧪 Test Case

### Test Script
```lua
local function OnCanPlayerResurrect(event, player)
    return false
end
RegisterPlayerEvent(59, OnCanPlayerResurrect)
```

### 📸 Test Results

https://github.com/user-attachments/assets/82c5dc1e-40be-49dd-99b8-e6dabed735d5