### PR TITLE
Feat(LuaEngine/PlayerHooks): Add Skill base player hooks

### DIFF
--- a/src/ElunaLuaEngine_SC.cpp
+++ b/src/ElunaLuaEngine_SC.cpp
@@ -812,6 +812,21 @@ public:
     {
         sEluna->OnCreatureKilledByPet(player, killed);
     }
+
+    bool CanPlayerUpdateSkill(Player* player, uint32 skill_id) override
+    {
+        return sEluna->OnCanPlayerUpdateSkill(player, skill_id);
+    }
+
+    void OnBeforePlayerUpdateSkill(Player* player, uint32 skill_id, uint32& value, uint32 max, uint32 step) override
+    {
+        sEluna->OnBeforePlayerUpdateSkill(player, skill_id, value, max, step);
+    }
+
+    void OnPlayerUpdateSkill(Player* player, uint32 skill_id, uint32 value, uint32 max, uint32 step, uint32 new_value) override
+    {
+        sEluna->OnPlayerUpdateSkill(player, skill_id, value, max, step, new_value);
+    }
 };
 
 class Eluna_ServerScript : public ServerScript

--- a/src/LuaEngine/Hooks.h
+++ b/src/LuaEngine/Hooks.h
@@ -221,6 +221,9 @@ namespace Hooks
         PLAYER_EVENT_ON_GROUP_ROLL_REWARD_ITEM  =     56,       // (event, player, item, count, voteType, roll)
         PLAYER_EVENT_ON_BG_DESERTION            =     57,       // (event, player, type)
         PLAYER_EVENT_ON_PET_KILL                =     58,       // (event, player, killer)
+        PLAYER_EVENT_ON_CAN_UPDATE_SKILL        =     59,       // (event, player, skill_id) -- Can return true or false
+        PLAYER_EVENT_ON_BEFORE_UPDATE_SKILL     =     60,       // (event, player, skill_id, value, max, step) -- Can return new amount
+        PLAYER_EVENT_ON_UPDATE_SKILL            =     61,       // (event, player, skill_id, value, max, step, new_value)
 
         PLAYER_EVENT_COUNT
     };

--- a/src/LuaEngine/LuaEngine.h
+++ b/src/LuaEngine/LuaEngine.h
@@ -447,6 +447,9 @@ public:
     void OnGroupRollRewardItem(Player* player, Item* item, uint32 count, RollVote voteType, Roll* roll);
     void OnBattlegroundDesertion(Player* player, const BattlegroundDesertionType type);
     void OnCreatureKilledByPet(Player* player, Creature* killed);
+    bool OnCanPlayerUpdateSkill(Player* player, uint32 skill_id);
+    void OnBeforePlayerUpdateSkill(Player* player, uint32 skill_id, uint32& value, uint32 max, uint32 step);
+    void OnPlayerUpdateSkill(Player* player, uint32 skill_id, uint32 value, uint32 max, uint32 step, uint32 new_value);
 
     /* Vehicle */
     void OnInstall(Vehicle* vehicle);

--- a/src/LuaEngine/hooks/PlayerHooks.cpp
+++ b/src/LuaEngine/hooks/PlayerHooks.cpp
@@ -706,3 +706,50 @@ void Eluna::OnCreatureKilledByPet(Player* player, Creature* killed)
     Push(killed);
     CallAllFunctions(PlayerEventBindings, key);
 }
+
+bool Eluna::OnCanPlayerUpdateSkill(Player* player, uint32 skill_id)
+{
+    START_HOOK_WITH_RETVAL(PLAYER_EVENT_ON_CAN_UPDATE_SKILL, true);
+    Push(player);
+    Push(skill_id);
+    return CallAllFunctionsBool(PlayerEventBindings, key);
+}
+
+void Eluna::OnBeforePlayerUpdateSkill(Player* player, uint32 skill_id, uint32& value, uint32 max, uint32 step)
+{
+    START_HOOK(PLAYER_EVENT_ON_BEFORE_UPDATE_SKILL);
+    Push(player);
+    Push(skill_id);
+    Push(value);
+    Push(max);
+    Push(step);
+
+    int valueIndex = lua_gettop(L) -2;
+    int n = SetupStack(PlayerEventBindings, key, 5);
+    while (n > 0)
+    {
+        int r = CallOneFunction(n--, 5, 1);
+        if (lua_isnumber(L, r))
+        {
+            value = CHECKVAL<uint32>(L, r);
+            // Update the stack for subsequent calls.
+            ReplaceArgument(value, valueIndex);
+        }
+
+        lua_pop(L, 1);
+    }
+
+    CleanUpStack(5);
+}
+
+void Eluna::OnPlayerUpdateSkill(Player* player, uint32 skill_id, uint32 value, uint32 max, uint32 step, uint32 new_value)
+{
+    START_HOOK(PLAYER_EVENT_ON_UPDATE_SKILL);
+    Push(player);
+    Push(skill_id);
+    Push(value);
+    Push(max);
+    Push(step);
+    Push(new_value);
+    CallAllFunctions(PlayerEventBindings, key);
+}


### PR DESCRIPTION
## 📝 Description

This pull request introduces a new Hook in `mod-eluna` for `player`:

- `PLAYER_EVENT_ON_CAN_RESURRECT`

## 🚨 Prerequisites

> [!WARNING]
> Requires the following dependency:
> - [AzerothCore PR #21273](https://github.com/azerothcore/azerothcore-wotlk/pull/21273)


## 🆕 New Hooks Overview

#### Example
```lua
local function OnPlayerCanUpdateSkill(event, player, skill_id)
    print("OnPlayerCanUpdateSkill", event, player, skill_id)
    return true
end
RegisterPlayerEvent(59, OnPlayerCanUpdateSkill)

local function OnBeforePlayerUpdateSkill(event, player, skill_id, value, max, step)
    print("OnBeforePlayerUpdateSkill", event, player, skill_id, value, max, step)
    return value + (step * 2)
end
RegisterPlayerEvent(60, OnBeforePlayerUpdateSkill)

local function OnPlayerUpdateSkill(event, player, skill_id, value, max, step)
    print("OnPlayerUpdateSkill", event, player, skill_id, value, max, step)
end
RegisterPlayerEvent(61, OnPlayerUpdateSkill)
```

## 🧪 Test Case

### Test Script
```lua
local function OnPlayerCanUpdateSkill(event, player, skill_id)
    print("OnPlayerCanUpdateSkill", event, player, skill_id)
    return true
end
RegisterPlayerEvent(59, OnPlayerCanUpdateSkill)

local function OnBeforePlayerUpdateSkill(event, player, skill_id, value, max, step)
    print("OnBeforePlayerUpdateSkill", event, player, skill_id, value, max, step)
    return value + (step * 2)
end
RegisterPlayerEvent(60, OnBeforePlayerUpdateSkill)

local function OnPlayerUpdateSkill(event, player, skill_id, value, max, step)
    print("OnPlayerUpdateSkill", event, player, skill_id, value, max, step)
end
RegisterPlayerEvent(61, OnPlayerUpdateSkill)
```

### 📸 Test Results

https://github.com/user-attachments/assets/9ef95c51-bc91-4dcb-a8cd-b13fdca317c6