### PR TITLE
Feat(LuaEngine/GameObjectMethods): Add SetRespawnDelay

### DIFF
--- a/src/LuaEngine/LuaFunctions.cpp
+++ b/src/LuaEngine/LuaFunctions.cpp
@@ -853,6 +853,7 @@ ElunaRegister<GameObject> GameObjectMethods[] =
     { "SetGoState", &LuaGameObject::SetGoState },
     { "SetLootState", &LuaGameObject::SetLootState },
     { "SetRespawnTime", &LuaGameObject::SetRespawnTime },
+    { "SetRespawnDelay", &LuaGameObject::SetRespawnDelay },
 
     // Boolean
     { "IsTransport", &LuaGameObject::IsTransport },

--- a/src/LuaEngine/methods/GameObjectMethods.h
+++ b/src/LuaEngine/methods/GameObjectMethods.h
@@ -353,5 +353,20 @@ namespace LuaGameObject
         go->SetRespawnTime(respawn);
         return 0;
     }
+
+    /**
+     * Sets the respawn or despawn time for the gameobject.
+     *
+     * Respawn time is also used as despawn time depending on gameobject settings
+     *
+     * @param int32 delay = 0 : cooldown time in seconds to respawn or despawn the object. 0 means never
+     */
+    int SetRespawnDelay(lua_State* L, GameObject* go)
+    {
+        int32 respawn = Eluna::CHECKVAL<int32>(L, 2);
+
+        go->SetRespawnDelay(respawn);
+        return 0;
+    }
 };
 #endif


### PR DESCRIPTION
## 📝 Description

This pull request introduces one new methods in `mod-eluna` for `GameObject`:

- `SetRespawnDelay`

## 🆕 New Methods Overview

### 1. `SetRespawnDelay(delay)`
Sets the respawn delay for a gameobject to a specific value.

#### Example
```lua
gameobject:SetRespawnDelay(30)
```