### PR TITLE
Feat(LuaEngine/ItemTemplateMethods): Add GetIcon method

### DIFF
--- a/src/LuaEngine/LuaFunctions.cpp
+++ b/src/LuaEngine/LuaFunctions.cpp
@@ -957,6 +957,7 @@ ElunaRegister<ItemTemplate> ItemTemplateMethods[] =
     { "GetAllowableRace", &LuaItemTemplate::GetAllowableRace },
     { "GetItemLevel", &LuaItemTemplate::GetItemLevel },
     { "GetRequiredLevel", &LuaItemTemplate::GetRequiredLevel },
+    { "GetIcon", &LuaItemTemplate::GetIcon },
     { NULL, NULL }
 };
 

--- a/src/LuaEngine/methods/ItemTemplateMethods.h
+++ b/src/LuaEngine/methods/ItemTemplateMethods.h
@@ -186,6 +186,22 @@ namespace LuaItemTemplate
         Eluna::Push(L, itemTemplate->RequiredLevel);
         return 1;
     }
+
+    /**
+     * Returns the icon is used by this [ItemTemplate].
+     * 
+     * @return string itemIcon
+     */
+    int GetIcon(lua_State* L, ItemTemplate* itemTemplate)
+    {   
+        uint32 display_id = itemTemplate->DisplayInfoID;
+        
+        ItemDisplayInfoEntry const* displayInfo = sItemDisplayInfoStore.LookupEntry(display_id);       
+        const char* icon = displayInfo->inventoryIcon;
+
+        Eluna::Push(L, icon);
+        return 1;
+    }
 }
 
 #endif


### PR DESCRIPTION
## 📝 Description

This pull request introduces one new methods in `mod-eluna` for `ItemTemplate`:

- `SetRespawnDelay`

## 🆕 New Methods Overview

### 1. `GetIcon()`
Get the ItemTemplate icon.

#### Example
```lua
itemtemplate:GetIcon()
```