### PR TITLE
fix(LuaEngine/CreatureMethods): reputation rewards refactored by AC

### DIFF
--- a/src/LuaEngine/methods/CreatureMethods.h
+++ b/src/LuaEngine/methods/CreatureMethods.h
@@ -47,7 +47,7 @@ namespace LuaCreature
      */
     int IsReputationGainDisabled(lua_State* L, Creature* creature)
     {
-        Eluna::Push(L, creature->IsReputationGainDisabled());
+        Eluna::Push(L, creature->IsReputationRewardDisabled());
         return 1;
     }
 
@@ -984,7 +984,7 @@ namespace LuaCreature
     {
         bool disable = Eluna::CHECKVAL<bool>(L, 2, true);
 
-        creature->SetDisableReputationGain(disable);
+        creature->SetReputationRewardDisabled(disable);
         return 0;
     }
 


### PR DESCRIPTION
There's been some reputation rewards refactoring in AC. This fix doesn't break the Eluna API

[Breaking Commit](https://github.com/azerothcore/azerothcore-wotlk/commit/17412174be2282560b321544996b1ca23a67cb45#diff-52a101f6175cb16c8a3879c92fcad3f9f4a263435ead333466a0f0f9428f00ceL362)