### PR TITLE
fix(LuaEngine/Reload) - Await callbacks before reloading, to not crash on callback

### DIFF
--- a/src/LuaEngine/LuaEngine.cpp
+++ b/src/LuaEngine/LuaEngine.cpp
@@ -127,6 +127,12 @@ void Eluna::_ReloadEluna()
     LOCK_ELUNA;
     ASSERT(IsInitialized());
 
+    if (!sEluna->CanReload())
+    {
+        sEluna->reloadScheduled = true;
+        return;
+    }
+    
     if (eConfigMgr->GetOption<bool>("Eluna.PlayerAnnounceReload", false))
         eWorldSessionMgr->SendServerMessage(SERVER_MSG_STRING, "Reloading Eluna...");
     else
@@ -147,6 +153,7 @@ void Eluna::_ReloadEluna()
     // Run scripts from laoded paths
     sEluna->RunScripts();
 
+    sEluna->reloadScheduled = false;
     reload = false;
 }
 

--- a/src/LuaEngine/LuaEngine.h
+++ b/src/LuaEngine/LuaEngine.h
@@ -88,6 +88,14 @@ struct LuaScript
 class ELUNA_GAME_API Eluna
 {
 public:
+    void IncrementCallbacks() { pendingCallbacks++; }
+	void DecrementCallbacks() 
+	{ 
+		pendingCallbacks--; 
+		if (pendingCallbacks == 0 && reloadScheduled)
+			_ReloadEluna();
+	}
+    bool CanReload() const { return pendingCallbacks == 0; }
     typedef std::list<LuaScript> ScriptList;
 
     typedef std::recursive_mutex LockType;
@@ -97,6 +105,8 @@ public:
     const std::string& GetRequireCPath() const { return lua_requirecpath; }
 
 private:
+    std::atomic<int> pendingCallbacks{0};
+    std::atomic<bool> reloadScheduled{false};
     static bool reload;
     static bool initialized;
     static LockType lock;

--- a/src/LuaEngine/methods/GlobalMethods.h
+++ b/src/LuaEngine/methods/GlobalMethods.h
@@ -1318,6 +1318,9 @@ namespace LuaGlobalFunctions
             luaL_argerror(L, 2, "unable to make a ref to function");
             return 0;
         }
+   
+	   // Increment pending callbacks counter
+	   Eluna::GEluna->IncrementCallbacks();
 
         Eluna::GEluna->queryProcessor.AddCallback(db.AsyncQuery(query).WithCallback([L, funcRef](QueryResult result)
             {
@@ -1335,6 +1338,9 @@ namespace LuaGlobalFunctions
                 Eluna::GEluna->ExecuteCall(1, 0);
 
                 luaL_unref(L, LUA_REGISTRYINDEX, funcRef);
+				
+			   // Decrement pending callbacks counter
+			   Eluna::GEluna->DecrementCallbacks();
             }));
 
         return 0;


### PR DESCRIPTION
Eluna reloads close the Lua engine, then opens it again. Callbacks from queries run before it is closed have no reference after this, and lead to a crash once received. This schedules reloads until after all pending callbacks have been processed.