### PR TITLE
feat(LuaEngine/Packet): Add support ReadPackedGUID

### DIFF
--- a/src/LuaEngine/LuaFunctions.cpp
+++ b/src/LuaEngine/LuaFunctions.cpp
@@ -1186,6 +1186,7 @@ ElunaRegister<WorldPacket> PacketMethods[] =
     { "ReadLong", &LuaPacket::ReadLong },
     { "ReadULong", &LuaPacket::ReadULong },
     { "ReadGUID", &LuaPacket::ReadGUID },
+    { "ReadPackedGUID", &LuaPacket::ReadPackedGUID },
     { "ReadString", &LuaPacket::ReadString },
     { "ReadFloat", &LuaPacket::ReadFloat },
     { "ReadDouble", &LuaPacket::ReadDouble },

--- a/src/LuaEngine/methods/WorldPacketMethods.h
+++ b/src/LuaEngine/methods/WorldPacketMethods.h
@@ -174,6 +174,19 @@ namespace LuaPacket
     }
 
     /**
+     * Reads and returns an unsigned 16-bit integer value from the [WorldPacket].
+     *
+     * @return Packed ObjectGuid value : value returned as string
+     */
+    int ReadPackedGUID(lua_State* L, WorldPacket* packet)
+    {
+        uint64 guid;
+        packet->readPackGUID(guid);
+        Eluna::Push(L, guid);
+        return 1;
+    }
+	
+    /**
      * Reads and returns a string value from the [WorldPacket].
      *
      * @return string value


### PR DESCRIPTION
Adds support for reading packed GUIDs in worldpackets (see e.g., packets SMSG_MOVE_GRAVITY_DISABLE, SMSG_MOVE_GRAVITY_ENABLE, SMSG_SPLINE_MOVE_START_SWIM, SMSG_SPLINE_MOVE_STOP_SWIM, SMSG_DESTRUCTIBLE_BUILDING_DAMAGE, and others that use PackGUID instead of a full GUID), and closes https://github.com/azerothcore/mod-eluna/issues/194