### PR TITLE
Fix Eluna events being 2 time too fast

### DIFF
--- a/src/ElunaLuaEngine_SC.cpp
+++ b/src/ElunaLuaEngine_SC.cpp
@@ -1010,19 +1010,6 @@ public:
     }
 };
 
-class Eluna_UnitScript : public UnitScript
-{
-public:
-    Eluna_UnitScript() : UnitScript("Eluna_UnitScript", true, {
-        UNITHOOK_ON_UNIT_UPDATE
-    }) { }
-
-    void OnUnitUpdate(Unit* unit, uint32 diff) override
-    {
-        unit->elunaEvents->Update(diff);
-    }
-};
-
 class Eluna_VehicleScript : public VehicleScript
 {
 public:
@@ -1216,7 +1203,6 @@ void AddSC_ElunaLuaEngine()
     new Eluna_ServerScript();
     new Eluna_SpellSC();
     new Eluna_TicketScript();
-    new Eluna_UnitScript();
     new Eluna_VehicleScript();
     new Eluna_WorldObjectScript();
     new Eluna_WorldScript();


### PR DESCRIPTION
This code

`elunaEvents->Update(diff);`

Is called in both OnWorldObjectUpdate and OnUnitUpdate

Because of that, events on Unit are triggered twice as fast

creature:RegisterEvent(Function, 2000, 0)
is called every 1 second