### PR TITLE
Add GetReactState to CreatureMethods and GetKnownTaxiNodes, SetKnownTaxiNodes to PlayerMethods

### DIFF
--- a/src/LuaEngine/LuaFunctions.cpp
+++ b/src/LuaEngine/LuaFunctions.cpp
@@ -799,6 +799,7 @@ ElunaRegister<Creature> CreatureMethods[] =
     { "SetNPCFlags", &LuaCreature::SetNPCFlags },
     { "SetUnitFlags", &LuaCreature::SetUnitFlags },
     { "SetUnitFlagsTwo", &LuaCreature::SetUnitFlagsTwo },
+    { "GetReactState", &LuaCreature::GetReactState },
     { "SetReactState", &LuaCreature::SetReactState },
     { "SetDeathState", &LuaCreature::SetDeathState },
     { "SetWalk", &LuaCreature::SetWalk },

--- a/src/LuaEngine/LuaFunctions.cpp
+++ b/src/LuaEngine/LuaFunctions.cpp
@@ -540,6 +540,7 @@ ElunaRegister<Player> PlayerMethods[] =
     { "GetPlayerSettingValue", &LuaPlayer::GetPlayerSettingValue },
     { "GetTrader", &LuaPlayer::GetTrader },
     { "GetBonusTalentCount", &LuaPlayer::GetBonusTalentCount },
+    { "GetKnownTaxiNodes", &LuaPlayer::GetKnownTaxiNodes },
 
     // Setters
     { "AdvanceSkillsToMax", &LuaPlayer::AdvanceSkillsToMax },
@@ -556,7 +557,6 @@ ElunaRegister<Player> PlayerMethods[] =
     { "SetLifetimeKills", &LuaPlayer::SetLifetimeKills },
     { "SetGameMaster", &LuaPlayer::SetGameMaster },
     { "SetGMChat", &LuaPlayer::SetGMChat },
-    { "GetKnownTaxiNodes", &LuaPlayer::GetKnownTaxiNodes },
     { "SetKnownTaxiNodes", &LuaPlayer::SetKnownTaxiNodes },
     { "SetTaxiCheat", &LuaPlayer::SetTaxiCheat },
     { "SetGMVisible", &LuaPlayer::SetGMVisible },
@@ -784,6 +784,7 @@ ElunaRegister<Creature> CreatureMethods[] =
     { "GetShieldBlockValue", &LuaCreature::GetShieldBlockValue },
     { "GetDBTableGUIDLow", &LuaCreature::GetDBTableGUIDLow },
     { "GetCreatureFamily", &LuaCreature::GetCreatureFamily },
+    { "GetReactState", &LuaCreature::GetReactState },
 
     // Setters
     { "SetRegeneratingHealth", &LuaCreature::SetRegeneratingHealth },
@@ -801,7 +802,6 @@ ElunaRegister<Creature> CreatureMethods[] =
     { "SetNPCFlags", &LuaCreature::SetNPCFlags },
     { "SetUnitFlags", &LuaCreature::SetUnitFlags },
     { "SetUnitFlagsTwo", &LuaCreature::SetUnitFlagsTwo },
-    { "GetReactState", &LuaCreature::GetReactState },
     { "SetReactState", &LuaCreature::SetReactState },
     { "SetDeathState", &LuaCreature::SetDeathState },
     { "SetWalk", &LuaCreature::SetWalk },

--- a/src/LuaEngine/LuaFunctions.cpp
+++ b/src/LuaEngine/LuaFunctions.cpp
@@ -556,6 +556,8 @@ ElunaRegister<Player> PlayerMethods[] =
     { "SetLifetimeKills", &LuaPlayer::SetLifetimeKills },
     { "SetGameMaster", &LuaPlayer::SetGameMaster },
     { "SetGMChat", &LuaPlayer::SetGMChat },
+    { "GetKnownTaxiNodes", &LuaPlayer::GetKnownTaxiNodes },
+    { "SetKnownTaxiNodes", &LuaPlayer::SetKnownTaxiNodes },
     { "SetTaxiCheat", &LuaPlayer::SetTaxiCheat },
     { "SetGMVisible", &LuaPlayer::SetGMVisible },
     { "SetPvPDeath", &LuaPlayer::SetPvPDeath },

--- a/src/LuaEngine/methods/CreatureMethods.h
+++ b/src/LuaEngine/methods/CreatureMethods.h
@@ -879,6 +879,18 @@ namespace LuaCreature
     }
 
     /**
+    * Gets the [Creature]'s current ReactState.
+    *
+    * @return [ReactState] The current react state of the creature.
+    */
+    int GetReactState(lua_State* L, Creature* creature)
+    {
+        ReactStates state = creature->GetReactState();
+        lua_pushinteger(L, (int)state);
+        return 1;
+    }
+
+    /**
      * Sets the [Creature]'s ReactState to `state`.
      *
      * @param [ReactState] state

--- a/src/LuaEngine/methods/CreatureMethods.h
+++ b/src/LuaEngine/methods/CreatureMethods.h
@@ -842,6 +842,18 @@ namespace LuaCreature
     }
 
     /**
+    * Gets the [Creature]'s current ReactState.
+    *
+    * @return [ReactState] The current react state of the creature.
+    */
+    int GetReactState(lua_State* L, Creature* creature)
+    {
+        ReactStates state = creature->GetReactState();
+        lua_pushinteger(L, (int)state);
+        return 1;
+    }
+
+    /**
      * Sets the [Creature]'s NPC flags to `flags`.
      *
      * @param [NPCFlags] flags
@@ -876,18 +888,6 @@ namespace LuaCreature
         uint32 flags = Eluna::CHECKVAL<uint32>(L, 2);
         creature->SetUInt32Value(UNIT_FIELD_FLAGS_2, flags);
         return 0;
-    }
-
-    /**
-    * Gets the [Creature]'s current ReactState.
-    *
-    * @return [ReactState] The current react state of the creature.
-    */
-    int GetReactState(lua_State* L, Creature* creature)
-    {
-        ReactStates state = creature->GetReactState();
-        lua_pushinteger(L, (int)state);
-        return 1;
     }
 
     /**

--- a/src/LuaEngine/methods/CreatureMethods.h
+++ b/src/LuaEngine/methods/CreatureMethods.h
@@ -842,10 +842,19 @@ namespace LuaCreature
     }
 
     /**
-    * Gets the [Creature]'s current ReactState.
-    *
-    * @return [ReactState] The current react state of the creature.
-    */
+     * Returns the [Creature]'s current ReactState.
+     *
+     * <pre>
+     * enum ReactState
+     * {
+     *     REACT_PASSIVE       = 0,
+     *     REACT_DEFENSIVE     = 1,
+     *     REACT_AGGRESSIVE    = 2
+     * };
+     * </pre>
+     *
+     * @return [ReactState] state
+     */
     int GetReactState(lua_State* L, Creature* creature)
     {
         ReactStates state = creature->GetReactState();

--- a/src/LuaEngine/methods/PlayerMethods.h
+++ b/src/LuaEngine/methods/PlayerMethods.h
@@ -1685,7 +1685,7 @@ namespace LuaPlayer
                 {
                     uint8 nodeId = (i * 32) + bit + 1;
                     lua_pushinteger(L, nodeId);
-                    lua_rawseti(L, -2, luaL_len(L, -2) + 1);
+                    lua_rawseti(L, -2, lua_rawlen(L, -2) + 1);
                 }
             }
         }

--- a/src/LuaEngine/methods/PlayerMethods.h
+++ b/src/LuaEngine/methods/PlayerMethods.h
@@ -1659,6 +1659,40 @@ namespace LuaPlayer
         return 1;
     }
 
+    /**
+    * Returns known taxi nodes (flight paths) that the player has unlocked.
+    *
+    * @return table<int> A table containing the IDs of the known taxi nodes.
+    */
+    int GetKnownTaxiNodes(lua_State* L, Player* player)
+    {
+        if (!player)
+            return 0;
+
+        lua_newtable(L);
+
+        ByteBuffer data;
+        player->m_taxi.AppendTaximaskTo(data, false);
+
+        for (uint8 i = 0; i < TaxiMaskSize; i++)
+        {
+            uint32 mask;
+            data >> mask;
+
+            for (uint8 bit = 0; bit < 32; bit++)
+            {
+                if (mask & (1 << bit))
+                {
+                    uint8 nodeId = (i * 32) + bit + 1;
+                    lua_pushinteger(L, nodeId);
+                    lua_rawseti(L, -2, luaL_len(L, -2) + 1);
+                }
+            }
+        }
+
+        return 1;
+    }
+
     /*int GetRecruiterId(lua_State* L, Player* player)
     {
         Eluna::Push(L, player->GetSession()->GetRecruiterId());
@@ -1890,6 +1924,38 @@ namespace LuaPlayer
         bool on = Eluna::CHECKVAL<bool>(L, 2, true);
 
         player->SetGMVisible(on);
+        return 0;
+    }
+
+    /**
+    * Sets the player's known taxi nodes (flight paths).
+    *
+    * @param table<int> A table containing the taxi node IDs to set as known.
+    */
+    int SetKnownTaxiNodes(lua_State* L, Player* player)
+    {
+        if (!player)
+            return 0;
+    
+        if (!lua_istable(L, 2))
+        {
+            return 0;
+        }
+    
+        lua_pushnil(L);
+    
+        while (lua_next(L, 2) != 0)
+        {
+            uint32 nodeId = luaL_checkinteger(L, -1);
+    
+            if (nodeId > 0) 
+            {
+                player->m_taxi.SetTaximaskNode(nodeId);
+            }
+    
+            lua_pop(L, 1);
+        }
+    
         return 0;
     }
 

--- a/src/LuaEngine/methods/PlayerMethods.h
+++ b/src/LuaEngine/methods/PlayerMethods.h
@@ -1938,9 +1938,7 @@ namespace LuaPlayer
             return 0;
     
         if (!lua_istable(L, 2))
-        {
             return 0;
-        }
     
         lua_pushnil(L);
     
@@ -1949,9 +1947,7 @@ namespace LuaPlayer
             uint32 nodeId = luaL_checkinteger(L, -1);
     
             if (nodeId > 0) 
-            {
                 player->m_taxi.SetTaximaskNode(nodeId);
-            }
     
             lua_pop(L, 1);
         }

--- a/src/LuaEngine/methods/PlayerMethods.h
+++ b/src/LuaEngine/methods/PlayerMethods.h
@@ -1660,10 +1660,10 @@ namespace LuaPlayer
     }
 
     /**
-    * Returns known taxi nodes (flight paths) that the player has unlocked.
-    *
-    * @return table<int> A table containing the IDs of the known taxi nodes.
-    */
+     * Returns known taxi nodes (flight paths) that the player has unlocked.
+     *
+     * @return table nodes : A table containing the IDs of the known taxi nodes
+     */
     int GetKnownTaxiNodes(lua_State* L, Player* player)
     {
         if (!player)
@@ -1928,10 +1928,10 @@ namespace LuaPlayer
     }
 
     /**
-    * Sets the player's known taxi nodes (flight paths).
-    *
-    * @param table<int> A table containing the taxi node IDs to set as known.
-    */
+     * Sets the player's known taxi nodes (flight paths).
+     *
+     * @param table nodes : A table containing the taxi node IDs to set as known
+     */
     int SetKnownTaxiNodes(lua_State* L, Player* player)
     {
         if (!player)


### PR DESCRIPTION
- Adds GetReactState() to CreatureMethods.h.  This will return if a creature is passive, defensive or aggressive.  Eluna previously had the ability to SetReactState, but it was missing a method for retrieving the current react state.

- Adds GetKnownTaxiNodes() to PlayerMethods.h.  This will return a table of known taxi node IDs that the player has unlocked.

- Adds SetKnownTaxiNodes() to PlayerMethods.h.  This will allow you to set player's known taxi nodes using a table of IDs.

**Example of the new taxi node retrieval:**
<img width="922" height="396" alt="image" src="https://github.com/user-attachments/assets/f77ad46b-8a25-4bb4-9157-d4c334094faa" />

<img width="892" height="292" alt="image" src="https://github.com/user-attachments/assets/37ad70a4-d0fd-4a57-802a-125d12644717" />
