### PR TITLE
feat(ElunaFileWatcher): Add file watcher and autoreload for mod-eluna

### DIFF
--- a/conf/mod_eluna.conf.dist
+++ b/conf/mod_eluna.conf.dist
@@ -37,6 +37,20 @@
 #                    Below are a set of "standard" paths used by most package managers.
 #                    "/usr/local/lib/lua/%s/?.so;/usr/lib/x86_64-linux-gnu/lua/%s/?.so;/usr/local/lib/lua/%s/loadall.so;"
 #       Default:     ""
+#
+#   Eluna.AutoReload
+#       Description: Enable or disable automatic reloading of Lua scripts when files are modified.
+#                    This feature watches the script directory for changes and automatically
+#                    triggers a reload when .lua files are added, modified, or deleted.
+#                    Useful for development but should be disabled in production environments.
+#       Default:    false - (disabled)
+#                   true  - (enabled)
+#
+#   Eluna.AutoReloadInterval
+#       Description: Sets the interval in seconds between file system checks for auto-reload.
+#                    Lower values provide faster detection but use more CPU resources.
+#                    Higher values reduce CPU usage but increase detection delay.
+#       Default:    1 - (check every 1 second)
 
 Eluna.Enabled = true
 Eluna.TraceBack = false
@@ -44,6 +58,8 @@ Eluna.ScriptPath = "lua_scripts"
 Eluna.PlayerAnnounceReload = false
 Eluna.RequirePaths = ""
 Eluna.RequireCPaths = ""
+Eluna.AutoReload = false
+Eluna.AutoReloadInterval = 1
 
 ###################################################################################################
 # LOGGING SYSTEM SETTINGS

--- a/src/LuaEngine/ElunaFileWatcher.cpp
+++ b/src/LuaEngine/ElunaFileWatcher.cpp
@@ -1,0 +1,211 @@
+/*
+* Copyright (C) 2010 - 2016 Eluna Lua Engine <http://emudevs.com/>
+* This program is free software licensed under GPL version 3
+* Please see the included DOCS/LICENSE.md for more information
+*/
+
+#include "ElunaFileWatcher.h"
+#include "LuaEngine.h"
+#include "ElunaUtility.h"
+#include <boost/filesystem.hpp>
+
+ElunaFileWatcher::ElunaFileWatcher() : running(false), checkInterval(1)
+{
+}
+
+ElunaFileWatcher::~ElunaFileWatcher()
+{
+    StopWatching();
+}
+
+void ElunaFileWatcher::StartWatching(const std::string& scriptPath, uint32 intervalSeconds)
+{
+    if (running.load())
+    {
+        ELUNA_LOG_DEBUG("[ElunaFileWatcher]: Already watching files");
+        return;
+    }
+
+    if (scriptPath.empty())
+    {
+        ELUNA_LOG_ERROR("[ElunaFileWatcher]: Cannot start watching - script path is empty");
+        return;
+    }
+
+    watchPath = scriptPath;
+    checkInterval = intervalSeconds;
+    running.store(true);
+
+    ScanDirectory(watchPath);
+
+    watcherThread = std::thread(&ElunaFileWatcher::WatchLoop, this);
+    
+    ELUNA_LOG_INFO("[ElunaFileWatcher]: Started watching '{}' (interval: {}s)", watchPath, checkInterval);
+}
+
+void ElunaFileWatcher::StopWatching()
+{
+    if (!running.load())
+        return;
+
+    running.store(false);
+
+    if (watcherThread.joinable())
+        watcherThread.join();
+
+    fileTimestamps.clear();
+    
+    ELUNA_LOG_INFO("[ElunaFileWatcher]: Stopped watching files");
+}
+
+void ElunaFileWatcher::WatchLoop()
+{
+    while (running.load())
+    {
+        try
+        {
+            CheckForChanges();
+        }
+        catch (const std::exception& e)
+        {
+            ELUNA_LOG_ERROR("[ElunaFileWatcher]: Error during file watching: {}", e.what());
+        }
+
+        std::this_thread::sleep_for(std::chrono::seconds(checkInterval));
+    }
+}
+
+void ElunaFileWatcher::ScanDirectory(const std::string& path)
+{
+    try
+    {
+        boost::filesystem::path dir(path);
+        
+        if (!boost::filesystem::exists(dir) || !boost::filesystem::is_directory(dir))
+            return;
+
+        boost::filesystem::directory_iterator end_iter;
+        
+        for (boost::filesystem::directory_iterator dir_iter(dir); dir_iter != end_iter; ++dir_iter)
+        {
+            std::string fullpath = dir_iter->path().generic_string();
+            
+            if (boost::filesystem::is_directory(dir_iter->status()))
+            {
+                ScanDirectory(fullpath);
+            }
+            else if (boost::filesystem::is_regular_file(dir_iter->status()))
+            {
+                std::string filename = dir_iter->path().filename().generic_string();
+                
+                if (filename.length() > 4 && filename.substr(filename.length() - 4) == ".lua")
+                {
+                    fileTimestamps[fullpath] = boost::filesystem::last_write_time(dir_iter->path());
+                }
+            }
+        }
+    }
+    catch (const std::exception& e)
+    {
+        ELUNA_LOG_ERROR("[ElunaFileWatcher]: Error scanning directory '{}': {}", path, e.what());
+    }
+}
+
+void ElunaFileWatcher::CheckForChanges()
+{
+    bool hasChanges = false;
+    
+    try
+    {
+        boost::filesystem::path dir(watchPath);
+        
+        if (!boost::filesystem::exists(dir) || !boost::filesystem::is_directory(dir))
+            return;
+
+        boost::filesystem::directory_iterator end_iter;
+        
+        for (boost::filesystem::directory_iterator dir_iter(dir); dir_iter != end_iter; ++dir_iter)
+        {
+            if (ShouldReloadFile(dir_iter->path().generic_string()))
+                hasChanges = true;
+        }
+        
+        for (auto it = fileTimestamps.begin(); it != fileTimestamps.end();)
+        {
+            if (!boost::filesystem::exists(it->first))
+            {
+                ELUNA_LOG_DEBUG("[ElunaFileWatcher]: File deleted: {}", it->first);
+                it = fileTimestamps.erase(it);
+                hasChanges = true;
+            }
+            else
+            {
+                ++it;
+            }
+        }
+    }
+    catch (const std::exception& e)
+    {
+        ELUNA_LOG_ERROR("[ElunaFileWatcher]: Error checking for changes: {}", e.what());
+        return;
+    }
+
+    if (hasChanges)
+    {
+        ELUNA_LOG_INFO("[ElunaFileWatcher]: Lua script changes detected - triggering reload");
+        Eluna::ReloadEluna();
+        
+        ScanDirectory(watchPath);
+    }
+}
+
+bool ElunaFileWatcher::ShouldReloadFile(const std::string& filepath)
+{
+    try
+    {
+        boost::filesystem::path file(filepath);
+        
+        if (boost::filesystem::is_directory(file))
+        {
+            boost::filesystem::directory_iterator end_iter;
+            
+            for (boost::filesystem::directory_iterator dir_iter(file); dir_iter != end_iter; ++dir_iter)
+            {
+                if (ShouldReloadFile(dir_iter->path().generic_string()))
+                    return true;
+            }
+            return false;
+        }
+        
+        if (!boost::filesystem::is_regular_file(file))
+            return false;
+            
+        std::string filename = file.filename().generic_string();
+        
+        if (filename.length() <= 4 || filename.substr(filename.length() - 4) != ".lua")
+            return false;
+            
+        auto currentTime = boost::filesystem::last_write_time(file);
+        auto it = fileTimestamps.find(filepath);
+        
+        if (it == fileTimestamps.end())
+        {
+            ELUNA_LOG_DEBUG("[ElunaFileWatcher]: New file detected: {}", filepath);
+            fileTimestamps[filepath] = currentTime;
+            return true;
+        }
+        
+        if (it->second != currentTime)
+        {
+            ELUNA_LOG_DEBUG("[ElunaFileWatcher]: File modified: {}", filepath);
+            it->second = currentTime;
+            return true;
+        }
+    }
+    catch (const std::exception& e)
+    {
+        ELUNA_LOG_ERROR("[ElunaFileWatcher]: Error checking file '{}': {}", filepath, e.what());
+    }
+    
+    return false;
+}

--- a/src/LuaEngine/ElunaFileWatcher.h
+++ b/src/LuaEngine/ElunaFileWatcher.h
@@ -1,0 +1,42 @@
+/*
+* Copyright (C) 2010 - 2016 Eluna Lua Engine <http://emudevs.com/>
+* This program is free software licensed under GPL version 3
+* Please see the included DOCS/LICENSE.md for more information
+*/
+
+#ifndef ELUNA_FILE_WATCHER_H
+#define ELUNA_FILE_WATCHER_H
+
+#include <thread>
+#include <atomic>
+#include <map>
+#include <string>
+#include <chrono>
+#include <boost/filesystem.hpp>
+#include "Common.h"
+
+class ElunaFileWatcher
+{
+public:
+    ElunaFileWatcher();
+    ~ElunaFileWatcher();
+
+    void StartWatching(const std::string& scriptPath, uint32 intervalSeconds = 1);
+    void StopWatching();
+    bool IsWatching() const { return running.load(); }
+
+private:
+    void WatchLoop();
+    void ScanDirectory(const std::string& path);
+    void CheckForChanges();
+    bool ShouldReloadFile(const std::string& filepath);
+
+    std::thread watcherThread;
+    std::atomic<bool> running;
+    std::string watchPath;
+    uint32 checkInterval;
+    
+    std::map<std::string, std::time_t> fileTimestamps;
+};
+
+#endif

--- a/src/LuaEngine/LuaEngine.cpp
+++ b/src/LuaEngine/LuaEngine.cpp
@@ -45,6 +45,7 @@ Eluna* Eluna::GEluna = NULL;
 bool Eluna::reload = false;
 bool Eluna::initialized = false;
 Eluna::LockType Eluna::lock;
+std::unique_ptr<ElunaFileWatcher> Eluna::fileWatcher;
 
 extern void RegisterFunctions(Eluna* E);
 
@@ -65,12 +66,27 @@ void Eluna::Initialize()
 
     // Create global eluna
     GEluna = new Eluna();
+
+    // Start file watcher if enabled
+    if (eConfigMgr->GetOption<bool>("Eluna.AutoReload", false))
+    {
+        uint32 watchInterval = eConfigMgr->GetOption<uint32>("Eluna.AutoReloadInterval", 1);
+        fileWatcher = std::make_unique<ElunaFileWatcher>();
+        fileWatcher->StartWatching(lua_folderpath, watchInterval);
+    }
 }
 
 void Eluna::Uninitialize()
 {
     LOCK_ELUNA;
     ASSERT(IsInitialized());
+
+    // Stop file watcher
+    if (fileWatcher)
+    {
+        fileWatcher->StopWatching();
+        fileWatcher.reset();
+    }
 
     delete GEluna;
     GEluna = NULL;

--- a/src/LuaEngine/LuaEngine.h
+++ b/src/LuaEngine/LuaEngine.h
@@ -23,6 +23,7 @@
 #include "HttpManager.h"
 #include "EventEmitter.h"
 #include "TicketMgr.h"
+#include "ElunaFileWatcher.h"
 #include <mutex>
 #include <memory>
 
@@ -100,6 +101,7 @@ private:
     static bool reload;
     static bool initialized;
     static LockType lock;
+    static std::unique_ptr<ElunaFileWatcher> fileWatcher;
 
     // Lua script locations
     static ScriptList lua_scripts;


### PR DESCRIPTION
Implementation of a basic autoreload system when modifying a Lua script or implementing a new Lua script, without using ESFW. Instead, I use a “polling” system with Boost.