### PR TITLE
feat(GameObject): GetSpawnId method

### DIFF
--- a/src/LuaEngine/LuaFunctions.cpp
+++ b/src/LuaEngine/LuaFunctions.cpp
@@ -941,7 +941,7 @@ ElunaRegister<GameObject> GameObjectMethods[] =
     { "GetLootState", &LuaGameObject::GetLootState },
     { "GetLootRecipient", &LuaGameObject::GetLootRecipient },
     { "GetLootRecipientGroup", &LuaGameObject::GetLootRecipientGroup },
-    { "GetDBTableGUIDLow", &LuaGameObject::GetDBTableGUIDLow },
+    { "GetSpawnId", &LuaGameObject::GetSpawnId },
 
     // Setters
     { "SetGoState", &LuaGameObject::SetGoState },

--- a/src/LuaEngine/methods/GameObjectMethods.h
+++ b/src/LuaEngine/methods/GameObjectMethods.h
@@ -146,11 +146,11 @@ namespace LuaGameObject
     }
 
     /**
-     * Returns the guid of the [GameObject] that is used as the ID in the database
-     *
-     * @return uint32 dbguid
-     */
-    int GetDBTableGUIDLow(lua_State* L, GameObject* go)
+    * Returns the spawn ID for this [GameObject].
+    *
+    * @return uint32 spawnId
+    */
+    int GetSpawnId(lua_State* L, GameObject* go)
     {
         Eluna::Push(L, go->GetSpawnId());
         return 1;


### PR DESCRIPTION
Similarly to PR #300, this is for getting the spawn Id of a gameobject.  This function actually already exists `GetDBTableGUIDLow`, but I think renaming it for consistency is better.