### PR TITLE
 refactor: ServerEvent - OnStartup, OnBeforeConfigLoad, OnConfigLoad

### DIFF
--- a/src/ElunaLuaEngine_SC.cpp
+++ b/src/ElunaLuaEngine_SC.cpp
@@ -1111,14 +1111,17 @@ public:
             ///- Initialize Lua Engine
             LOG_INFO("eluna", "Initialize Eluna Lua Engine...");
             Eluna::Initialize();
+
+            if(sEluna->IsInitialized())
+                sEluna->RunScripts();
         }
 
-        sEluna->OnConfigLoad(reload, true);
+        sEluna->OnBeforeConfigLoad(reload);
     }
 
     void OnAfterConfigLoad(bool reload) override
     {
-        sEluna->OnConfigLoad(reload, false);
+        sEluna->OnAfterConfigLoad(reload);
     }
 
     void OnShutdownInitiate(ShutdownExitCode code, ShutdownMask mask) override
@@ -1153,10 +1156,7 @@ public:
 
     void OnBeforeWorldInitialized() override
     {
-        ///- Run eluna scripts.
-        // in multithread foreach: run scripts
-        sEluna->RunScripts();
-        sEluna->OnConfigLoad(false, false); // Must be done after Eluna is initialized and scripts have run.
+        sEluna->OnBeforeWorldInitialized();
     }
 };
 

--- a/src/LuaEngine/Hooks.h
+++ b/src/LuaEngine/Hooks.h
@@ -113,7 +113,7 @@ namespace Hooks
 
         // World
         WORLD_EVENT_ON_OPEN_STATE_CHANGE        =     8,        // (event, open) - Needs core support on Mangos
-        WORLD_EVENT_ON_CONFIG_LOAD              =     9,        // (event, reload)
+        WORLD_EVENT_ON_AFTER_CONFIG_LOAD        =     9,        // (event, reload)
         // UNUSED                               =     10,
         WORLD_EVENT_ON_SHUTDOWN_INIT            =     11,       // (event, code, mask)
         WORLD_EVENT_ON_SHUTDOWN_CANCEL          =     12,       // (event)
@@ -156,6 +156,9 @@ namespace Hooks
 
         GAME_EVENT_START                        =     34,       // (event, gameeventid)
         GAME_EVENT_STOP                         =     35,       // (event, gameeventid)
+
+        WORLD_EVENT_ON_BEFORE_WORLD_INITIALIZED =     36,       // (event)
+        WORLD_EVENT_ON_BEFORE_CONFIG_LOAD       =     37,       // (event, reload)
 
         SERVER_EVENT_COUNT
     };

--- a/src/LuaEngine/LuaEngine.h
+++ b/src/LuaEngine/LuaEngine.h
@@ -556,13 +556,15 @@ public:
 
     /* World */
     void OnOpenStateChange(bool open);
-    void OnConfigLoad(bool reload, bool isBefore);
+    void OnAfterConfigLoad(bool reload);
     void OnShutdownInitiate(ShutdownExitCode code, ShutdownMask mask);
     void OnShutdownCancel();
     void OnStartup();
     void OnShutdown();
     void OnGameEventStart(uint32 eventid);
     void OnGameEventStop(uint32 eventid);
+    void OnBeforeWorldInitialized();
+    void OnBeforeConfigLoad(bool reload);
 
     /* Battle Ground */
     void OnBGStart(BattleGround* bg, BattleGroundTypeId bgId, uint32 instanceId);
@@ -575,7 +577,7 @@ public:
     void OnTicketClose(GmTicket* ticket);
     void OnTicketUpdateLastChange(GmTicket* ticket);
     void OnTicketResolve(GmTicket* ticket);
-  
+
     /* Spell */
     void OnSpellPrepare(Unit* caster, Spell* spell, SpellInfo const* spellInfo);
     void OnSpellCast(Unit* caster, Spell* spell, SpellInfo const* spellInfo, bool skipCheck);

--- a/src/LuaEngine/hooks/ServerHooks.cpp
+++ b/src/LuaEngine/hooks/ServerHooks.cpp
@@ -227,11 +227,10 @@ void Eluna::OnOpenStateChange(bool open)
     CallAllFunctions(ServerEventBindings, key);
 }
 
-void Eluna::OnConfigLoad(bool reload, bool isBefore)
+void Eluna::OnAfterConfigLoad(bool reload)
 {
-    START_HOOK(WORLD_EVENT_ON_CONFIG_LOAD);
+    START_HOOK(WORLD_EVENT_ON_AFTER_CONFIG_LOAD);
     Push(reload);
-    Push(isBefore);
     CallAllFunctions(ServerEventBindings, key);
 }
 
@@ -275,6 +274,19 @@ void Eluna::OnStartup()
 void Eluna::OnShutdown()
 {
     START_HOOK(WORLD_EVENT_ON_SHUTDOWN);
+    CallAllFunctions(ServerEventBindings, key);
+}
+
+void Eluna::OnBeforeWorldInitialized()
+{
+    START_HOOK(WORLD_EVENT_ON_BEFORE_WORLD_INITIALIZED);
+    CallAllFunctions(ServerEventBindings, key);
+}
+
+void Eluna::OnBeforeConfigLoad(bool reload)
+{
+    START_HOOK(WORLD_EVENT_ON_BEFORE_CONFIG_LOAD);
+    Push(reload);
     CallAllFunctions(ServerEventBindings, key);
 }
 

--- a/src/LuaEngine/methods/GlobalMethods.h
+++ b/src/LuaEngine/methods/GlobalMethods.h
@@ -649,7 +649,7 @@ namespace LuaGlobalFunctions
      *
      *         // World
      *         WORLD_EVENT_ON_OPEN_STATE_CHANGE        =     8,        // (event, open) - Needs core support on Mangos
-     *         WORLD_EVENT_ON_CONFIG_LOAD              =     9,        // (event, reload)
+     *         WORLD_EVENT_ON_AFTER_CONFIG_LOAD        =     9,        // (event, reload)
      *         // UNUSED                               =     10,
      *         WORLD_EVENT_ON_SHUTDOWN_INIT            =     11,       // (event, code, mask)
      *         WORLD_EVENT_ON_SHUTDOWN_CANCEL          =     12,       // (event)
@@ -692,6 +692,9 @@ namespace LuaGlobalFunctions
      *
      *         GAME_EVENT_START                        =     34,       // (event, gameeventid)
      *         GAME_EVENT_STOP                         =     35,       // (event, gameeventid)
+     *
+     *         WORLD_EVENT_ON_BEFORE_WORLD_INITIALIZED =     36,       // (event)
+     *         WORLD_EVENT_ON_BEFORE_CONFIG_LOAD       =     37,       // (event, reload)
      *     };
      *
      * @proto cancel = (event, function)


### PR DESCRIPTION
To make Handle scripts better handle the OnBeforeConfigLoad event, I added it and moved the execution of Lua scripts directly before the Hook call, otherwise it is useless if no reload is performed. I also separated the OnBefore and OnAfter for the initialization of the World and Configs (which are directly related, so I didn't split this PR into several parts because everything is connected).