### PR TITLE
fix(ElunaLuaEngine): Add nullptr checks to OnDamage and OnHeal methods

### DIFF
--- a/src/ElunaLuaEngine_SC.cpp
+++ b/src/ElunaLuaEngine_SC.cpp
@@ -1219,6 +1219,9 @@ public:
 
     void OnHeal(Unit* healer, Unit* receiver, uint32& gain) override
     {
+        if (!receiver) return;
+        if (!healer) return;
+		
         if (healer->IsPlayer())
             sEluna->OnPlayerHeal(healer->ToPlayer(), receiver, gain);
 
@@ -1228,6 +1231,9 @@ public:
 
     void OnDamage(Unit* attacker, Unit* receiver, uint32& damage) override
     {
+        if (!receiver) return;
+        if (!attacker) return;
+
         if (attacker->IsPlayer())
             sEluna->OnPlayerDamage(attacker->ToPlayer(), receiver, damage);
 


### PR DESCRIPTION
Fixes issue #319

These crashes were introduced with commit 1153fcaef774266b0be74a79373630b7c336fade

This has been tested by me as well as a few other people in the comment thread of the issue.