### PR TITLE
feat(LootMethods): Add support for adding/retrieving quest items and item stacking

### DIFF
--- a/src/LuaEngine/LuaFunctions.cpp
+++ b/src/LuaEngine/LuaFunctions.cpp
@@ -1751,6 +1751,7 @@ ElunaRegister<Loot> LootMethods[] =
     // Get
     { "GetMoney", &LuaLoot::GetMoney },
     { "GetItems", &LuaLoot::GetItems },
+    { "GetQuestItems", &LuaLoot::GetQuestItems },
     { "GetUnlootedCount", &LuaLoot::GetUnlootedCount },
     { "GetLootType", &LuaLoot::GetLootType },
     { "GetRoundRobinPlayer", &LuaLoot::GetRoundRobinPlayer },


### PR DESCRIPTION
- Currently we can GetItems() via loot->items.size(), but this does not include quest items.  This PR adds support for quest items now via GetQuestItems() and updating a few other methods to also include quest items in their logic.

- I also added an additional bool parameter to the AddItem() method for allowing items to be stacked as shown in the below screenshot.  I am working on an aoe loot lua script and having the option for items be stackable is very useful.

In the screenshot below, we can see stackable items with the bool true and the ability to merge quest items as well.

<img width="640" height="616" alt="image" src="https://github.com/user-attachments/assets/387057c2-63ea-405f-a644-516b7f2d6354" />
